### PR TITLE
Update Orion and EthSigner to latest versions to fix Privacy test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,6 +60,7 @@ jobs:
       - run:
           name: Install Packages - Java 11
           command: |
+            sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 78BD65473CB3BD13 5DC22404A6F9F1CA
             sudo add-apt-repository -y ppa:openjdk-r/ppa
             sudo apt update
             sudo apt install -y openjdk-11-jdk

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -93,6 +93,7 @@ jobs:
       - run:
           name: Install Packages - Java 11
           command: |
+            sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 78BD65473CB3BD13 5DC22404A6F9F1CA
             sudo add-apt-repository -y ppa:openjdk-r/ppa
             sudo apt update
             sudo apt install -y openjdk-11-jdk

--- a/dsl/src/main/java/tech/pegasys/peeps/privacy/Orion.java
+++ b/dsl/src/main/java/tech/pegasys/peeps/privacy/Orion.java
@@ -46,7 +46,7 @@ public class Orion implements NetworkMember {
   private static final String AM_I_ALIVE_ENDPOINT = "/upcheck";
 
   // TODO there should be the 'latest' version
-  private static final String ORION_IMAGE = "pegasyseng/orion:develop";
+  private static final String ORION_IMAGE = "consensys/quorum-orion:develop";
 
   private static final int CONTAINER_PEER_TO_PEER_PORT = 8080;
   private static final int CONTAINER_HTTP_RPC_PORT = 8888;

--- a/dsl/src/main/java/tech/pegasys/peeps/signer/EthSigner.java
+++ b/dsl/src/main/java/tech/pegasys/peeps/signer/EthSigner.java
@@ -45,7 +45,6 @@ public class EthSigner implements NetworkMember {
 
   //  private static final String ETH_SIGNER_IMAGE = "pegasyseng/ethsigner:latest";
   private static final String ETH_SIGNER_IMAGE = "consensys/quorum-ethsigner:develop";
-  private static final String CONTAINER_DATA_PATH = "/tmp/";
   private static final int CONTAINER_HTTP_RPC_PORT = 8545;
   private static final Duration DOWNSTREAM_TIMEOUT = Duration.ofSeconds(10);
   private static final String CONTAINER_KEY_FILE = "/etc/ethsigner/key_file.v3";
@@ -138,8 +137,6 @@ public class EthSigner implements NetworkMember {
     return Lists.newArrayList(
         "--logging",
         "DEBUG",
-        "--data-path",
-        CONTAINER_DATA_PATH,
         "--http-listen-host",
         "0.0.0.0",
         "--http-listen-port",

--- a/dsl/src/main/java/tech/pegasys/peeps/signer/EthSigner.java
+++ b/dsl/src/main/java/tech/pegasys/peeps/signer/EthSigner.java
@@ -44,8 +44,8 @@ public class EthSigner implements NetworkMember {
   private static final int ALIVE_STATUS_CODE = 200;
 
   //  private static final String ETH_SIGNER_IMAGE = "pegasyseng/ethsigner:latest";
-  private static final String ETH_SIGNER_IMAGE = "pegasyseng/ethsigner:develop";
-  private static final String CONTAINER_DATA_PATH = "/etc/ethsigner/tmp/";
+  private static final String ETH_SIGNER_IMAGE = "consensys/quorum-ethsigner:develop";
+  private static final String CONTAINER_DATA_PATH = "/tmp/";
   private static final int CONTAINER_HTTP_RPC_PORT = 8545;
   private static final Duration DOWNSTREAM_TIMEOUT = Duration.ofSeconds(10);
   private static final String CONTAINER_KEY_FILE = "/etc/ethsigner/key_file.v3";
@@ -137,7 +137,7 @@ public class EthSigner implements NetworkMember {
   private List<String> standardCommandLineOptions() {
     return Lists.newArrayList(
         "--logging",
-        "INFO",
+        "DEBUG",
         "--data-path",
         CONTAINER_DATA_PATH,
         "--http-listen-host",

--- a/end-to-end-tests/src/test/java/tech/pegasys/peeps/privacy/PrivacyContractDeploymentTest.java
+++ b/end-to-end-tests/src/test/java/tech/pegasys/peeps/privacy/PrivacyContractDeploymentTest.java
@@ -21,10 +21,9 @@ import tech.pegasys.peeps.network.Network;
 import tech.pegasys.peeps.node.model.Hash;
 import tech.pegasys.peeps.privacy.model.PrivacyGroup;
 
-import org.apache.commons.codec.DecoderException;
 import org.junit.jupiter.api.Test;
 
-public class PrivacyContracDeploymentTest extends NetworkTest {
+public class PrivacyContractDeploymentTest extends NetworkTest {
 
   private final NodeConfiguration nodeAlpha = NodeConfiguration.ALPHA;
   private final SignerConfiguration signer = SignerConfiguration.ALPHA;
@@ -49,7 +48,7 @@ public class PrivacyContracDeploymentTest extends NetworkTest {
   }
 
   @Test
-  public void deploymentMustSucceed() throws DecoderException {
+  public void deploymentMustSucceed() {
     final PrivacyGroup group = new PrivacyGroup(privacyManagerAlpha.id(), privacyManagerBeta.id());
 
     final Hash pmt =


### PR DESCRIPTION
Fix the PrivacyContractDeploymentTest so it now runs

* Update to latest EthSigner and Orion docker images
* Fix issue with EthSigner not starting due permissions creating socket file in data directory