### PR TITLE
Remove Fixed keys and Ids

### DIFF
--- a/dsl/src/main/java/tech/pegasys/peeps/json/rpc/RpcClient.java
+++ b/dsl/src/main/java/tech/pegasys/peeps/json/rpc/RpcClient.java
@@ -12,10 +12,10 @@
  */
 package tech.pegasys.peeps.json.rpc;
 
-import static com.github.dockerjava.core.MediaType.APPLICATION_JSON;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 import static io.vertx.core.http.HttpHeaders.CONTENT_TYPE;
+import static org.testcontainers.shaded.com.github.dockerjava.core.MediaType.APPLICATION_JSON;
 
 import tech.pegasys.peeps.json.Json;
 

--- a/dsl/src/main/java/tech/pegasys/peeps/network/Network.java
+++ b/dsl/src/main/java/tech/pegasys/peeps/network/Network.java
@@ -21,9 +21,9 @@ import static tech.pegasys.peeps.util.Await.await;
 import tech.pegasys.peeps.network.subnet.Subnet;
 import tech.pegasys.peeps.node.Account;
 import tech.pegasys.peeps.node.Besu;
+import tech.pegasys.peeps.node.EthereumAddressProvider;
 import tech.pegasys.peeps.node.GoQuorum;
 import tech.pegasys.peeps.node.NodeVerify;
-import tech.pegasys.peeps.node.EthereumAddressProvider;
 import tech.pegasys.peeps.node.Web3Provider;
 import tech.pegasys.peeps.node.Web3ProviderConfigurationBuilder;
 import tech.pegasys.peeps.node.Web3ProviderType;
@@ -165,10 +165,14 @@ public class Network implements Closeable {
   }
 
   public Web3Provider addNode(
-      final String nodeIdentifier, final KeyPair nodeKeys, final Web3ProviderType nodeType, final
-  SignerConfiguration wallet) {
+      final String nodeIdentifier,
+      final KeyPair nodeKeys,
+      final Web3ProviderType nodeType,
+      final SignerConfiguration wallet) {
     return addNode(
-        new Web3ProviderConfigurationBuilder().withIdentity(nodeIdentifier).withNodeKeys(nodeKeys)
+        new Web3ProviderConfigurationBuilder()
+            .withIdentity(nodeIdentifier)
+            .withNodeKeys(nodeKeys)
             .withWallet(wallet),
         nodeType);
   }
@@ -376,17 +380,16 @@ public class Network implements Closeable {
   }
 
   private String bootnodeEnodeAddresses() {
-    return nodes
-        .parallelStream()
-        .map(Web3Provider::enodeAddress)
-        .collect(Collectors.joining(","));
+    return nodes.parallelStream().map(Web3Provider::enodeAddress).collect(Collectors.joining(","));
   }
 
   private void everyMember(Consumer<NetworkMember> action) {
     // start the first node (which has NO bootnodes).
-    final NetworkMember bootNode = members.get(0); // TODO(tmm): Assumes this IS a Ethereum node
-    action.accept(bootNode);
-    members.parallelStream().filter(m -> !m.equals(bootNode)).forEach(action);
+    if (members.size() >= 1) {
+      final NetworkMember bootNode = members.get(0); // TODO(tmm): Assumes this IS a Ethereum node
+      action.accept(bootNode);
+      members.parallelStream().filter(m -> !m.equals(bootNode)).forEach(action);
+    }
   }
 
   private Genesis createGenesis(

--- a/dsl/src/main/java/tech/pegasys/peeps/network/Network.java
+++ b/dsl/src/main/java/tech/pegasys/peeps/network/Network.java
@@ -155,6 +155,12 @@ public class Network implements Closeable {
         Web3ProviderType.BESU);
   }
 
+  public Web3Provider addNode(final String nodeIdentifier, final KeyPair nodeKeys, final Web3ProviderType nodeType) {
+    return addNode(
+        new Web3ProviderConfigurationBuilder().withIdentity(nodeIdentifier).withNodeKeys(nodeKeys),
+        nodeType);
+  }
+
   public Web3Provider addNode(
       final String identity,
       final KeyPair nodeKeys,

--- a/dsl/src/main/java/tech/pegasys/peeps/node/Besu.java
+++ b/dsl/src/main/java/tech/pegasys/peeps/node/Besu.java
@@ -14,16 +14,13 @@ package tech.pegasys.peeps.node;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
-import com.google.common.io.Resources;
-import java.io.FilePermission;
+import tech.pegasys.peeps.util.DockerLogs;
+
 import java.io.IOException;
-import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.attribute.PosixFilePermissions;
-import tech.pegasys.peeps.util.DockerLogs;
-
 import java.time.Duration;
 import java.util.List;
 
@@ -74,11 +71,6 @@ public class Besu extends Web3Provider {
 
     LOG.info("Besu command line: {}", commandLineOptions);
     container.withCommand(commandLineOptions.toArray(new String[0])).waitingFor(liveliness());
-  }
-
-  @Override
-  public String getNodeName() {
-    return "Besu";
   }
 
   @Override
@@ -145,14 +137,15 @@ public class Besu extends Web3Provider {
     try {
       tempFile = Files.createTempFile("nodekey", ".priv");
       Files.setPosixFilePermissions(tempFile, PosixFilePermissions.fromString("rwxrwxrwx"));
-      Files.write(tempFile, config.getNodePrivateKey().getBytes(StandardCharsets.UTF_8));
+      Files.write(
+          tempFile,
+          config.getNodeKeys().secretKey().bytes().toHexString().getBytes(StandardCharsets.UTF_8));
     } catch (final IOException e) {
       throw new RuntimeException("Unable to create node key file", e);
     }
 
     container.withCopyFileToContainer(
-        MountableFile.forHostPath(tempFile),
-        CONTAINER_NODE_PRIVATE_KEY_FILE);
+        MountableFile.forHostPath(tempFile), CONTAINER_NODE_PRIVATE_KEY_FILE);
     commandLineOptions.addAll(
         Lists.newArrayList("--node-private-key-file", CONTAINER_NODE_PRIVATE_KEY_FILE));
   }

--- a/dsl/src/main/java/tech/pegasys/peeps/node/Besu.java
+++ b/dsl/src/main/java/tech/pegasys/peeps/node/Besu.java
@@ -14,6 +14,9 @@ package tech.pegasys.peeps.node;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
+import tech.pegasys.peeps.node.rpc.NodeRpc;
+import tech.pegasys.peeps.node.rpc.NodeRpcClient;
+import tech.pegasys.peeps.node.rpc.NodeRpcMandatoryResponse;
 import tech.pegasys.peeps.util.DockerLogs;
 
 import java.io.IOException;
@@ -41,7 +44,7 @@ public class Besu extends Web3Provider {
   private static final String AM_I_ALIVE_ENDPOINT = "/liveness";
   private static final int ALIVE_STATUS_CODE = 200;
 
-  private static final String BESU_IMAGE = "hyperledger/besu:develop";
+  private static final String BESU_IMAGE = "hyperledger/besu:21.1.1-SNAPSHOT-openjdk-11";
   private static final String CONTAINER_GENESIS_FILE = "/etc/besu/genesis.json";
   private static final String CONTAINER_PRIVACY_PUBLIC_KEY_FILE =
       "/etc/besu/privacy_public_key.pub";
@@ -53,7 +56,8 @@ public class Besu extends Web3Provider {
     super(
         config,
         new GenericContainer<>(BESU_IMAGE)
-            .withImagePullPolicy(PullPolicy.ageBased(Duration.ofHours(1))));
+            .withImagePullPolicy(PullPolicy.defaultPolicy()));
+
     final List<String> commandLineOptions = standardCommandLineOptions();
 
     addPeerToPeerHost(config, commandLineOptions);
@@ -87,7 +91,7 @@ public class Besu extends Web3Provider {
   private List<String> standardCommandLineOptions() {
     return Lists.newArrayList(
         "--logging",
-        "DEBUG",
+        "TRACE",
         "--miner-enabled",
         "--miner-coinbase",
         "1b23ba34ca45bb56aa67bc78be89ac00ca00da00",
@@ -98,7 +102,9 @@ public class Besu extends Web3Provider {
         "--rpc-http-enabled",
         "--rpc-ws-enabled",
         "--rpc-http-apis",
-        "ADMIN,ETH,NET,WEB3,EEA,PRIV");
+        "ADMIN,ETH,NET,WEB3,EEA,PRIV",
+        "--sync-mode",
+        "FULL");
   }
 
   private void addPeerToPeerHost(

--- a/dsl/src/main/java/tech/pegasys/peeps/node/Besu.java
+++ b/dsl/src/main/java/tech/pegasys/peeps/node/Besu.java
@@ -15,11 +15,13 @@ package tech.pegasys.peeps.node;
 import static com.google.common.base.Preconditions.checkArgument;
 
 import com.google.common.io.Resources;
+import java.io.FilePermission;
 import java.io.IOException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermissions;
 import tech.pegasys.peeps.util.DockerLogs;
 
 import java.time.Duration;
@@ -141,10 +143,9 @@ public class Besu extends Web3Provider {
 
     final Path tempFile;
     try {
-      final URL keyURL = Resources.getResource(config.getNodeKeyPrivateKeyResource().get());
-      final String text = Resources.toString(keyURL, StandardCharsets.UTF_8);
       tempFile = Files.createTempFile("nodekey", ".priv");
-      Files.write(tempFile, text.getBytes(StandardCharsets.UTF_8));
+      Files.setPosixFilePermissions(tempFile, PosixFilePermissions.fromString("rwxrwxrwx"));
+      Files.write(tempFile, config.getNodePrivateKey().getBytes(StandardCharsets.UTF_8));
     } catch (final IOException e) {
       throw new RuntimeException("Unable to create node key file", e);
     }

--- a/dsl/src/main/java/tech/pegasys/peeps/node/Besu.java
+++ b/dsl/src/main/java/tech/pegasys/peeps/node/Besu.java
@@ -14,9 +14,6 @@ package tech.pegasys.peeps.node;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
-import tech.pegasys.peeps.node.rpc.NodeRpc;
-import tech.pegasys.peeps.node.rpc.NodeRpcClient;
-import tech.pegasys.peeps.node.rpc.NodeRpcMandatoryResponse;
 import tech.pegasys.peeps.util.DockerLogs;
 
 import java.io.IOException;
@@ -24,7 +21,6 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.attribute.PosixFilePermissions;
-import java.time.Duration;
 import java.util.List;
 
 import com.google.common.collect.Lists;
@@ -54,9 +50,7 @@ public class Besu extends Web3Provider {
 
   public Besu(final Web3ProviderConfiguration config) {
     super(
-        config,
-        new GenericContainer<>(BESU_IMAGE)
-            .withImagePullPolicy(PullPolicy.defaultPolicy()));
+        config, new GenericContainer<>(BESU_IMAGE).withImagePullPolicy(PullPolicy.defaultPolicy()));
 
     final List<String> commandLineOptions = standardCommandLineOptions();
 

--- a/dsl/src/main/java/tech/pegasys/peeps/node/EthereumAddressProvider.java
+++ b/dsl/src/main/java/tech/pegasys/peeps/node/EthereumAddressProvider.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package tech.pegasys.peeps.node;
+
+import org.apache.tuweni.eth.Address;
+
+public interface EthereumAddressProvider {
+  Address getAddress();
+}

--- a/dsl/src/main/java/tech/pegasys/peeps/node/EthereumAddressProvider.java
+++ b/dsl/src/main/java/tech/pegasys/peeps/node/EthereumAddressProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright ConsenSys AG.
+ * Copyright 2021 ConsenSys AG.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -9,8 +9,6 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
- *
- * SPDX-License-Identifier: Apache-2.0
  */
 package tech.pegasys.peeps.node;
 

--- a/dsl/src/main/java/tech/pegasys/peeps/node/GoQuorum.java
+++ b/dsl/src/main/java/tech/pegasys/peeps/node/GoQuorum.java
@@ -59,13 +59,9 @@ public class GoQuorum extends Web3Provider {
         MountableFile.forHostPath(config.getGenesisFile()), CONTAINER_GENESIS_FILE);
     final List<String> entryPoint = Lists.newArrayList("/bin/sh", "-c");
     final String initCmd =
-        "mkdir -p '"
-            + DATA_DIR
-            + "/geth' && geth --datadir \""
-            + DATA_DIR
-            + "\" init "
-            + CONTAINER_GENESIS_FILE
-            + " && echo '##### GoQuorum INITIALISED #####' && ";
+        "mkdir -p '" + DATA_DIR + "/geth' && "
+            + "geth --datadir \"" + DATA_DIR + "\" init " + CONTAINER_GENESIS_FILE + " ** "
+            + " echo '##### GoQuorum INITIALISED #####' && ";
 
     addNodePrivateKey(config, commandLineOptions, container);
     //    if (config.isPrivacyEnabled()) {
@@ -151,7 +147,8 @@ public class GoQuorum extends Web3Provider {
       Files.setPosixFilePermissions(tempFile, PosixFilePermissions.fromString("rwxrwxrwx"));
       Files.write(
           tempFile,
-          config.getNodeKeys().secretKey().bytes().toHexString().getBytes(StandardCharsets.UTF_8));
+          config.getNodeKeys().secretKey().bytes().toUnprefixedHexString()
+              .getBytes(StandardCharsets.UTF_8));
     } catch (final IOException e) {
       throw new RuntimeException("Unable to create node key file", e);
     }

--- a/dsl/src/main/java/tech/pegasys/peeps/node/Web3Provider.java
+++ b/dsl/src/main/java/tech/pegasys/peeps/node/Web3Provider.java
@@ -16,9 +16,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static org.assertj.core.api.Assertions.assertThat;
 import static tech.pegasys.peeps.util.Await.await;
 
-import java.time.Duration;
-import org.apache.tuweni.bytes.Bytes;
-import org.apache.tuweni.eth.Address;
 import tech.pegasys.peeps.network.NetworkMember;
 import tech.pegasys.peeps.network.subnet.SubnetAddress;
 import tech.pegasys.peeps.node.model.EnodeHelpers;
@@ -27,7 +24,11 @@ import tech.pegasys.peeps.node.model.TransactionReceipt;
 import tech.pegasys.peeps.node.rpc.admin.NodeInfo;
 import tech.pegasys.peeps.node.verification.AccountValue;
 import tech.pegasys.peeps.node.verification.NodeValueTransition;
+import tech.pegasys.peeps.signer.rpc.SignerRpc;
+import tech.pegasys.peeps.signer.rpc.SignerRpcClient;
+import tech.pegasys.peeps.signer.rpc.SignerRpcMandatoryResponse;
 
+import java.time.Duration;
 import java.util.Collection;
 import java.util.Set;
 import java.util.function.Supplier;
@@ -36,10 +37,9 @@ import java.util.stream.Stream;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.eth.Address;
 import org.testcontainers.containers.GenericContainer;
-import tech.pegasys.peeps.signer.rpc.SignerRpc;
-import tech.pegasys.peeps.signer.rpc.SignerRpcClient;
-import tech.pegasys.peeps.signer.rpc.SignerRpcMandatoryResponse;
 
 public abstract class Web3Provider implements NetworkMember, EthereumAddressProvider {
 
@@ -62,7 +62,6 @@ public abstract class Web3Provider implements NetworkMember, EthereumAddressProv
   private String nodeId;
   private String enodeId;
 
-
   public Web3Provider(final Web3ProviderConfiguration config, final GenericContainer<?> container) {
     this.container = container;
     this.nodeRpc = new SignerRpcClient(config.getVertx(), Duration.ofSeconds(10), dockerLogs());
@@ -84,8 +83,12 @@ public abstract class Web3Provider implements NetworkMember, EthereumAddressProv
     try {
 
       container.start();
-      LOG.info("Starting {} : {},  {} ", identity, container.getDockerImageName(),
-          container.getContainerId(), container.getContainerInfo().getImageId());
+      LOG.info(
+          "Starting {} : {},  {} ",
+          identity,
+          container.getDockerImageName(),
+          container.getContainerId(),
+          container.getContainerInfo().getImageId());
 
       container.followOutput(
           outputFrame -> LOG.info("{}: {}", identity, outputFrame.getUtf8String()));

--- a/dsl/src/main/java/tech/pegasys/peeps/node/Web3ProviderConfiguration.java
+++ b/dsl/src/main/java/tech/pegasys/peeps/node/Web3ProviderConfiguration.java
@@ -13,15 +13,12 @@
 package tech.pegasys.peeps.node;
 
 import tech.pegasys.peeps.network.subnet.SubnetAddress;
-import tech.pegasys.peeps.node.model.NodeIdentifier;
-import tech.pegasys.peeps.node.model.NodeKey;
-import tech.pegasys.peeps.node.model.NodePrivateKeyResource;
-import tech.pegasys.peeps.node.model.NodePublicKeyResource;
 
 import java.nio.file.Path;
 import java.util.Optional;
 
 import io.vertx.core.Vertx;
+import org.apache.tuweni.crypto.SECP256K1.KeyPair;
 import org.testcontainers.containers.Network;
 
 public class Web3ProviderConfiguration {
@@ -29,12 +26,11 @@ public class Web3ProviderConfiguration {
   private final Path genesisFile;
   private final String enclavePublicKeyResource;
   private final String cors;
-  private final NodeIdentifier identity;
+  private final String identity;
   private final String bootnodeEnodeAddress;
   private final String privacyUrl;
   private final String privacyMarkerSigningPrivateKeyFile;
-  private final NodeKey ethereumIdentity;
-  private final String nodePrivateKey;
+  private final KeyPair nodeKeys;
 
   // TODO move these out, they are not related to the node, but test container setups
   private final Network containerNetwork;
@@ -50,10 +46,9 @@ public class Web3ProviderConfiguration {
       final Network containerNetwork,
       final Vertx vertx,
       final SubnetAddress ipAddress,
-      final NodeIdentifier identity,
-      final NodeKey ethereumIdentity,
-      final String bootnodeEnodeAddress,
-      final String nodePrivateKey) {
+      final String identity,
+      final KeyPair nodeKeys,
+      final String bootnodeEnodeAddress) {
     this.genesisFile = genesisFile;
     this.enclavePublicKeyResource = privacyManagerPublicKeyResource;
     this.privacyMarkerSigningPrivateKeyFile = privacyMarkerSigningPrivateKeyFile;
@@ -63,9 +58,8 @@ public class Web3ProviderConfiguration {
     this.vertx = vertx;
     this.ipAddress = ipAddress;
     this.identity = identity;
-    this.ethereumIdentity = ethereumIdentity;
+    this.nodeKeys = nodeKeys;
     this.bootnodeEnodeAddress = bootnodeEnodeAddress;
-    this.nodePrivateKey = nodePrivateKey;
   }
 
   public Path getGenesisFile() {
@@ -88,7 +82,7 @@ public class Web3ProviderConfiguration {
     return ipAddress;
   }
 
-  public NodeIdentifier getIdentity() {
+  public String getIdentity() {
     return identity;
   }
 
@@ -100,12 +94,8 @@ public class Web3ProviderConfiguration {
     return vertx;
   }
 
-  public NodePrivateKeyResource getNodeKeyPrivateKeyResource() {
-    return ethereumIdentity.nodePrivateKeyResource();
-  }
-
-  public NodePublicKeyResource getNodeKeyPublicKeyResource() {
-    return ethereumIdentity.nodePublicKeyResource();
+  public KeyPair getNodeKeys() {
+    return nodeKeys;
   }
 
   // TODO maybe split out privacy
@@ -119,9 +109,5 @@ public class Web3ProviderConfiguration {
 
   public Optional<String> getPrivacyMarkerSigningPrivateKeyFile() {
     return Optional.ofNullable(privacyMarkerSigningPrivateKeyFile);
-  }
-
-  public String getNodePrivateKey() {
-    return nodePrivateKey;
   }
 }

--- a/dsl/src/main/java/tech/pegasys/peeps/node/Web3ProviderConfiguration.java
+++ b/dsl/src/main/java/tech/pegasys/peeps/node/Web3ProviderConfiguration.java
@@ -12,8 +12,8 @@
  */
 package tech.pegasys.peeps.node;
 
-import java.util.List;
 import tech.pegasys.peeps.network.subnet.SubnetAddress;
+import tech.pegasys.peeps.signer.SignerConfiguration;
 
 import java.nio.file.Path;
 import java.util.Optional;
@@ -21,8 +21,6 @@ import java.util.Optional;
 import io.vertx.core.Vertx;
 import org.apache.tuweni.crypto.SECP256K1.KeyPair;
 import org.testcontainers.containers.Network;
-import tech.pegasys.peeps.signer.SignerConfiguration;
-import tech.pegasys.peeps.signer.model.WalletFileResources;
 
 public class Web3ProviderConfiguration {
 

--- a/dsl/src/main/java/tech/pegasys/peeps/node/Web3ProviderConfiguration.java
+++ b/dsl/src/main/java/tech/pegasys/peeps/node/Web3ProviderConfiguration.java
@@ -34,6 +34,7 @@ public class Web3ProviderConfiguration {
   private final String privacyUrl;
   private final String privacyMarkerSigningPrivateKeyFile;
   private final NodeKey ethereumIdentity;
+  private final String nodePrivateKey;
 
   // TODO move these out, they are not related to the node, but test container setups
   private final Network containerNetwork;
@@ -51,7 +52,8 @@ public class Web3ProviderConfiguration {
       final SubnetAddress ipAddress,
       final NodeIdentifier identity,
       final NodeKey ethereumIdentity,
-      final String bootnodeEnodeAddress) {
+      final String bootnodeEnodeAddress,
+      final String nodePrivateKey) {
     this.genesisFile = genesisFile;
     this.enclavePublicKeyResource = privacyManagerPublicKeyResource;
     this.privacyMarkerSigningPrivateKeyFile = privacyMarkerSigningPrivateKeyFile;
@@ -63,6 +65,7 @@ public class Web3ProviderConfiguration {
     this.identity = identity;
     this.ethereumIdentity = ethereumIdentity;
     this.bootnodeEnodeAddress = bootnodeEnodeAddress;
+    this.nodePrivateKey = nodePrivateKey;
   }
 
   public Path getGenesisFile() {
@@ -116,5 +119,9 @@ public class Web3ProviderConfiguration {
 
   public Optional<String> getPrivacyMarkerSigningPrivateKeyFile() {
     return Optional.ofNullable(privacyMarkerSigningPrivateKeyFile);
+  }
+
+  public String getNodePrivateKey() {
+    return nodePrivateKey;
   }
 }

--- a/dsl/src/main/java/tech/pegasys/peeps/node/Web3ProviderConfiguration.java
+++ b/dsl/src/main/java/tech/pegasys/peeps/node/Web3ProviderConfiguration.java
@@ -12,6 +12,7 @@
  */
 package tech.pegasys.peeps.node;
 
+import java.util.List;
 import tech.pegasys.peeps.network.subnet.SubnetAddress;
 
 import java.nio.file.Path;
@@ -20,6 +21,8 @@ import java.util.Optional;
 import io.vertx.core.Vertx;
 import org.apache.tuweni.crypto.SECP256K1.KeyPair;
 import org.testcontainers.containers.Network;
+import tech.pegasys.peeps.signer.SignerConfiguration;
+import tech.pegasys.peeps.signer.model.WalletFileResources;
 
 public class Web3ProviderConfiguration {
 
@@ -28,6 +31,7 @@ public class Web3ProviderConfiguration {
   private final String cors;
   private final String identity;
   private final String bootnodeEnodeAddress;
+  private final Optional<SignerConfiguration> wallet;
   private final String privacyUrl;
   private final String privacyMarkerSigningPrivateKeyFile;
   private final KeyPair nodeKeys;
@@ -48,7 +52,8 @@ public class Web3ProviderConfiguration {
       final SubnetAddress ipAddress,
       final String identity,
       final KeyPair nodeKeys,
-      final String bootnodeEnodeAddress) {
+      final String bootnodeEnodeAddress,
+      final SignerConfiguration wallet) {
     this.genesisFile = genesisFile;
     this.enclavePublicKeyResource = privacyManagerPublicKeyResource;
     this.privacyMarkerSigningPrivateKeyFile = privacyMarkerSigningPrivateKeyFile;
@@ -60,6 +65,7 @@ public class Web3ProviderConfiguration {
     this.identity = identity;
     this.nodeKeys = nodeKeys;
     this.bootnodeEnodeAddress = bootnodeEnodeAddress;
+    this.wallet = Optional.ofNullable(wallet);
   }
 
   public Path getGenesisFile() {
@@ -109,5 +115,9 @@ public class Web3ProviderConfiguration {
 
   public Optional<String> getPrivacyMarkerSigningPrivateKeyFile() {
     return Optional.ofNullable(privacyMarkerSigningPrivateKeyFile);
+  }
+
+  public Optional<SignerConfiguration> getWallet() {
+    return wallet;
   }
 }

--- a/dsl/src/main/java/tech/pegasys/peeps/node/Web3ProviderConfigurationBuilder.java
+++ b/dsl/src/main/java/tech/pegasys/peeps/node/Web3ProviderConfigurationBuilder.java
@@ -14,17 +14,12 @@ package tech.pegasys.peeps.node;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import com.google.common.io.Resources;
-import java.io.IOException;
-import java.net.URL;
-import java.nio.charset.StandardCharsets;
 import tech.pegasys.peeps.network.subnet.SubnetAddress;
 import tech.pegasys.peeps.node.genesis.BesuGenesisFile;
-import tech.pegasys.peeps.node.model.NodeIdentifier;
-import tech.pegasys.peeps.node.model.NodeKey;
 import tech.pegasys.peeps.privacy.Orion;
 
 import io.vertx.core.Vertx;
+import org.apache.tuweni.crypto.SECP256K1.KeyPair;
 import org.testcontainers.containers.Network;
 
 public class Web3ProviderConfigurationBuilder {
@@ -34,7 +29,7 @@ public class Web3ProviderConfigurationBuilder {
       "node/keys/pmt_signing.priv";
 
   private BesuGenesisFile genesisFile;
-  private NodeIdentifier frameworkIdentity;
+  private String identity;
 
   // TODO better typing then String
   private String privacyManagerPublicKeyFile;
@@ -42,7 +37,7 @@ public class Web3ProviderConfigurationBuilder {
   private String privacyTransactionManagerUrl;
   private String cors;
   private String bootnodeEnodeAddress;
-  private NodeKey ethereumIdentity;
+  private KeyPair nodeKeys;
 
   // TODO these into their own builder, not node related but test container related
   private Network containerNetwork;
@@ -79,8 +74,8 @@ public class Web3ProviderConfigurationBuilder {
     return this;
   }
 
-  public Web3ProviderConfigurationBuilder withIdentity(final NodeIdentifier identity) {
-    this.frameworkIdentity = identity;
+  public Web3ProviderConfigurationBuilder withIdentity(final String identity) {
+    this.identity = identity;
     return this;
   }
 
@@ -100,32 +95,19 @@ public class Web3ProviderConfigurationBuilder {
     return this;
   }
 
-  public Web3ProviderConfigurationBuilder withNodeKey(final NodeKey ethereumIdentity) {
-    this.ethereumIdentity = ethereumIdentity;
+  public Web3ProviderConfigurationBuilder withNodeKeys(final KeyPair nodeKeys) {
+    this.nodeKeys = nodeKeys;
     return this;
   }
 
   public Web3ProviderConfiguration build() {
     checkNotNull(genesisFile, "A genesis file path is mandatory");
-    checkNotNull(frameworkIdentity, "A NodeKey is mandatory");
+    checkNotNull(identity, "A NodeKey is mandatory");
     checkNotNull(vertx, "A Vertx instance is mandatory");
     checkNotNull(ipAddress, "Container IP address is mandatory");
     checkNotNull(containerNetwork, "Container network is mandatory");
-    checkNotNull(ethereumIdentity, "Ethereum identity is mandatory");
-    checkNotNull(
-        ethereumIdentity.nodePrivateKeyResource(),
-        "Private key resource for the Node Key is mandatory");
-    checkNotNull(
-        ethereumIdentity.nodePublicKeyResource(),
-        "Public key resource for the Node Key is mandatory");
-
-    final URL keyURL = Resources.getResource(ethereumIdentity.nodePrivateKeyResource().get());
-    final String privateKeyHex;
-    try {
-      privateKeyHex = Resources.toString(keyURL, StandardCharsets.UTF_8);
-    } catch (IOException e) {
-      throw new RuntimeException("Unable to extact priv key from Resource", e);
-    }
+    checkNotNull(nodeKeys, "Ethereum identity is mandatory");
+    checkNotNull(nodeKeys, "Node Key is mandatory");
 
     return new Web3ProviderConfiguration(
         genesisFile.getGenesisFile(),
@@ -136,9 +118,8 @@ public class Web3ProviderConfigurationBuilder {
         containerNetwork,
         vertx,
         ipAddress,
-        frameworkIdentity,
-        ethereumIdentity,
-        bootnodeEnodeAddress,
-        privateKeyHex);
+        identity,
+        nodeKeys,
+        bootnodeEnodeAddress);
   }
 }

--- a/dsl/src/main/java/tech/pegasys/peeps/node/Web3ProviderConfigurationBuilder.java
+++ b/dsl/src/main/java/tech/pegasys/peeps/node/Web3ProviderConfigurationBuilder.java
@@ -14,17 +14,14 @@ package tech.pegasys.peeps.node;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import java.util.List;
-import org.apache.commons.compress.utils.Lists;
 import tech.pegasys.peeps.network.subnet.SubnetAddress;
 import tech.pegasys.peeps.node.genesis.BesuGenesisFile;
 import tech.pegasys.peeps.privacy.Orion;
+import tech.pegasys.peeps.signer.SignerConfiguration;
 
 import io.vertx.core.Vertx;
 import org.apache.tuweni.crypto.SECP256K1.KeyPair;
 import org.testcontainers.containers.Network;
-import tech.pegasys.peeps.signer.SignerConfiguration;
-import tech.pegasys.peeps.signer.model.WalletFileResources;
 
 public class Web3ProviderConfigurationBuilder {
 

--- a/dsl/src/main/java/tech/pegasys/peeps/node/Web3ProviderConfigurationBuilder.java
+++ b/dsl/src/main/java/tech/pegasys/peeps/node/Web3ProviderConfigurationBuilder.java
@@ -14,6 +14,8 @@ package tech.pegasys.peeps.node;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import java.util.List;
+import org.apache.commons.compress.utils.Lists;
 import tech.pegasys.peeps.network.subnet.SubnetAddress;
 import tech.pegasys.peeps.node.genesis.BesuGenesisFile;
 import tech.pegasys.peeps.privacy.Orion;
@@ -21,6 +23,8 @@ import tech.pegasys.peeps.privacy.Orion;
 import io.vertx.core.Vertx;
 import org.apache.tuweni.crypto.SECP256K1.KeyPair;
 import org.testcontainers.containers.Network;
+import tech.pegasys.peeps.signer.SignerConfiguration;
+import tech.pegasys.peeps.signer.model.WalletFileResources;
 
 public class Web3ProviderConfigurationBuilder {
 
@@ -38,6 +42,7 @@ public class Web3ProviderConfigurationBuilder {
   private String cors;
   private String bootnodeEnodeAddress;
   private KeyPair nodeKeys;
+  private SignerConfiguration wallet;
 
   // TODO these into their own builder, not node related but test container related
   private Network containerNetwork;
@@ -100,6 +105,11 @@ public class Web3ProviderConfigurationBuilder {
     return this;
   }
 
+  public Web3ProviderConfigurationBuilder withWallet(final SignerConfiguration wallet) {
+    this.wallet = wallet;
+    return this;
+  }
+
   public Web3ProviderConfiguration build() {
     checkNotNull(genesisFile, "A genesis file path is mandatory");
     checkNotNull(identity, "A NodeKey is mandatory");
@@ -120,6 +130,7 @@ public class Web3ProviderConfigurationBuilder {
         ipAddress,
         identity,
         nodeKeys,
-        bootnodeEnodeAddress);
+        bootnodeEnodeAddress,
+        wallet);
   }
 }

--- a/dsl/src/main/java/tech/pegasys/peeps/node/Web3ProviderConfigurationBuilder.java
+++ b/dsl/src/main/java/tech/pegasys/peeps/node/Web3ProviderConfigurationBuilder.java
@@ -14,6 +14,10 @@ package tech.pegasys.peeps.node;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import com.google.common.io.Resources;
+import java.io.IOException;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import tech.pegasys.peeps.network.subnet.SubnetAddress;
 import tech.pegasys.peeps.node.genesis.BesuGenesisFile;
 import tech.pegasys.peeps.node.model.NodeIdentifier;
@@ -115,6 +119,14 @@ public class Web3ProviderConfigurationBuilder {
         ethereumIdentity.nodePublicKeyResource(),
         "Public key resource for the Node Key is mandatory");
 
+    final URL keyURL = Resources.getResource(ethereumIdentity.nodePrivateKeyResource().get());
+    final String privateKeyHex;
+    try {
+      privateKeyHex = Resources.toString(keyURL, StandardCharsets.UTF_8);
+    } catch (IOException e) {
+      throw new RuntimeException("Unable to extact priv key from Resource", e);
+    }
+
     return new Web3ProviderConfiguration(
         genesisFile.getGenesisFile(),
         privacyManagerPublicKeyFile,
@@ -126,6 +138,7 @@ public class Web3ProviderConfigurationBuilder {
         ipAddress,
         frameworkIdentity,
         ethereumIdentity,
-        bootnodeEnodeAddress);
+        bootnodeEnodeAddress,
+        privateKeyHex);
   }
 }

--- a/dsl/src/main/java/tech/pegasys/peeps/node/genesis/Genesis.java
+++ b/dsl/src/main/java/tech/pegasys/peeps/node/genesis/Genesis.java
@@ -74,17 +74,18 @@ public class Genesis {
 
   @JsonGetter("gasLimit")
   public String getGasLimit() {
-    return "0x47b760";
+    return "0x29B92700";
   }
 
   @JsonGetter("difficulty")
   public String getDifficulty() {
-    return "0x10000";
+    return "0x1";
   }
 
   @JsonGetter("mixHash")
   public String getMixHash() {
-    return "0x0000000000000000000000000000000000000000000000000000000000000000";
+    // This is REQUIRED for ibft, but doesn't hurt anything else (I hope).
+    return "0x63746963616c2062797a616e74696e65206661756c7420746f6c6572616e6365";
   }
 
   @JsonGetter("coinbase")

--- a/dsl/src/main/java/tech/pegasys/peeps/node/genesis/clique/CliqueConfig.java
+++ b/dsl/src/main/java/tech/pegasys/peeps/node/genesis/clique/CliqueConfig.java
@@ -12,7 +12,6 @@
  */
 package tech.pegasys.peeps.node.genesis.clique;
 
-import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonGetter;
 
 public class CliqueConfig {

--- a/dsl/src/main/java/tech/pegasys/peeps/node/genesis/clique/CliqueConfig.java
+++ b/dsl/src/main/java/tech/pegasys/peeps/node/genesis/clique/CliqueConfig.java
@@ -12,6 +12,7 @@
  */
 package tech.pegasys.peeps.node.genesis.clique;
 
+import com.fasterxml.jackson.annotation.JsonAlias;
 import com.fasterxml.jackson.annotation.JsonGetter;
 
 public class CliqueConfig {
@@ -33,8 +34,18 @@ public class CliqueConfig {
     return blockPeriodSeconds;
   }
 
+  @JsonGetter("period")
+  public int getPeriod() {
+    return blockPeriodSeconds;
+  }
+
   @JsonGetter("epochlength")
   public int getEpochLength() {
+    return epochLength;
+  }
+
+  @JsonGetter("epoch")
+  public int getEpoch() {
     return epochLength;
   }
 }

--- a/dsl/src/main/java/tech/pegasys/peeps/node/genesis/clique/GenesisExtraDataClique.java
+++ b/dsl/src/main/java/tech/pegasys/peeps/node/genesis/clique/GenesisExtraDataClique.java
@@ -20,7 +20,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.apache.tuweni.bytes.Bytes;
-import org.apache.tuweni.crypto.Hash;
 import org.apache.tuweni.eth.Address;
 
 public class GenesisExtraDataClique extends GenesisExtraData {

--- a/dsl/src/main/java/tech/pegasys/peeps/node/genesis/clique/GenesisExtraDataClique.java
+++ b/dsl/src/main/java/tech/pegasys/peeps/node/genesis/clique/GenesisExtraDataClique.java
@@ -12,7 +12,7 @@
  */
 package tech.pegasys.peeps.node.genesis.clique;
 
-import tech.pegasys.peeps.node.Web3Provider;
+import tech.pegasys.peeps.node.EthereumAddressProvider;
 import tech.pegasys.peeps.node.genesis.GenesisExtraData;
 
 import java.util.List;
@@ -25,20 +25,16 @@ import org.apache.tuweni.eth.Address;
 
 public class GenesisExtraDataClique extends GenesisExtraData {
 
-  public GenesisExtraDataClique(final Web3Provider... validators) {
+  public GenesisExtraDataClique(final EthereumAddressProvider... validators) {
     super(encode(validators));
   }
 
-  private static Bytes encode(final Web3Provider... validators) {
+  private static Bytes encode(final EthereumAddressProvider... validators) {
 
     return encode(
         Stream.of(validators)
             .parallel()
-            .map(
-                validator ->
-                    Address.fromBytes(
-                        Hash.keccak256(Bytes.fromHexString(validator.nodePublicKey()))
-                            .slice(12, 20)))
+            .map(EthereumAddressProvider::getAddress)
             .collect(Collectors.toList()));
   }
 

--- a/dsl/src/main/java/tech/pegasys/peeps/node/genesis/ibft/GenesisConfigIbftLegacy.java
+++ b/dsl/src/main/java/tech/pegasys/peeps/node/genesis/ibft/GenesisConfigIbftLegacy.java
@@ -25,7 +25,7 @@ public class GenesisConfigIbftLegacy extends GenesisConfig {
     this.consensusConfig = consensusConfig;
   }
 
-  @JsonGetter("ibft")
+  @JsonGetter("istanbul")
   public IbftLegacyConfig getConsensusConfig() {
     return consensusConfig;
   }

--- a/dsl/src/main/java/tech/pegasys/peeps/node/genesis/ibft/GenesisExtraDataIbftLegacy.java
+++ b/dsl/src/main/java/tech/pegasys/peeps/node/genesis/ibft/GenesisExtraDataIbftLegacy.java
@@ -12,7 +12,7 @@
  */
 package tech.pegasys.peeps.node.genesis.ibft;
 
-import tech.pegasys.peeps.node.Web3Provider;
+import tech.pegasys.peeps.node.EthereumAddressProvider;
 import tech.pegasys.peeps.node.genesis.GenesisExtraData;
 
 import java.util.Collections;
@@ -27,20 +27,16 @@ import org.apache.tuweni.rlp.RLP;
 
 public class GenesisExtraDataIbftLegacy extends GenesisExtraData {
 
-  public GenesisExtraDataIbftLegacy(final Web3Provider... validators) {
+  public GenesisExtraDataIbftLegacy(final EthereumAddressProvider... validators) {
     super(encode(validators));
   }
 
-  public static Bytes encode(final Web3Provider... validators) {
+  public static Bytes encode(final EthereumAddressProvider... validators) {
 
     return encode(
         Stream.of(validators)
             .parallel()
-            .map(
-                validator ->
-                    Address.fromBytes(
-                        Hash.keccak256(Bytes.fromHexString(validator.nodePublicKey()))
-                            .slice(12, 20)))
+            .map(EthereumAddressProvider::getAddress)
             .collect(Collectors.toList()));
   }
 

--- a/dsl/src/main/java/tech/pegasys/peeps/node/genesis/ibft/GenesisExtraDataIbftLegacy.java
+++ b/dsl/src/main/java/tech/pegasys/peeps/node/genesis/ibft/GenesisExtraDataIbftLegacy.java
@@ -21,7 +21,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.apache.tuweni.bytes.Bytes;
-import org.apache.tuweni.crypto.Hash;
 import org.apache.tuweni.eth.Address;
 import org.apache.tuweni.rlp.RLP;
 

--- a/dsl/src/main/java/tech/pegasys/peeps/node/genesis/ibft2/GenesisExtraDataIbft2.java
+++ b/dsl/src/main/java/tech/pegasys/peeps/node/genesis/ibft2/GenesisExtraDataIbft2.java
@@ -21,7 +21,6 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.apache.tuweni.bytes.Bytes;
-import org.apache.tuweni.crypto.Hash;
 import org.apache.tuweni.crypto.SECP256K1.Signature;
 import org.apache.tuweni.eth.Address;
 import org.apache.tuweni.rlp.RLP;

--- a/dsl/src/main/java/tech/pegasys/peeps/node/genesis/ibft2/GenesisExtraDataIbft2.java
+++ b/dsl/src/main/java/tech/pegasys/peeps/node/genesis/ibft2/GenesisExtraDataIbft2.java
@@ -12,7 +12,7 @@
  */
 package tech.pegasys.peeps.node.genesis.ibft2;
 
-import tech.pegasys.peeps.node.Web3Provider;
+import tech.pegasys.peeps.node.EthereumAddressProvider;
 import tech.pegasys.peeps.node.genesis.GenesisExtraData;
 
 import java.util.Collections;
@@ -28,20 +28,16 @@ import org.apache.tuweni.rlp.RLP;
 
 public class GenesisExtraDataIbft2 extends GenesisExtraData {
 
-  public GenesisExtraDataIbft2(final Web3Provider... validators) {
+  public GenesisExtraDataIbft2(final EthereumAddressProvider... validators) {
     super(encode(validators));
   }
 
-  public static Bytes encode(final Web3Provider... validators) {
+  public static Bytes encode(final EthereumAddressProvider... validators) {
 
     return encode(
         Stream.of(validators)
             .parallel()
-            .map(
-                validator ->
-                    Address.fromBytes(
-                        Hash.keccak256(Bytes.fromHexString(validator.nodePublicKey()))
-                            .slice(12, 20)))
+            .map(EthereumAddressProvider::getAddress)
             .collect(Collectors.toList()));
   }
 

--- a/dsl/src/main/java/tech/pegasys/peeps/signer/SignerConfiguration.java
+++ b/dsl/src/main/java/tech/pegasys/peeps/signer/SignerConfiguration.java
@@ -12,12 +12,13 @@
  */
 package tech.pegasys.peeps.signer;
 
-import org.apache.tuweni.eth.Address;
 import tech.pegasys.peeps.node.EthereumAddressProvider;
 import tech.pegasys.peeps.signer.model.SignerIdentifier;
 import tech.pegasys.peeps.signer.model.SignerKeyFileResource;
 import tech.pegasys.peeps.signer.model.SignerPasswordFileResource;
 import tech.pegasys.peeps.signer.model.WalletFileResources;
+
+import org.apache.tuweni.eth.Address;
 
 public class SignerConfiguration implements EthereumAddressProvider {
 
@@ -25,8 +26,11 @@ public class SignerConfiguration implements EthereumAddressProvider {
   private final SignerIdentifier id;
   private final WalletFileResources resources;
 
-  public SignerConfiguration(final String name,
-      final String keyResource, final String passwordResource, final Address address) {
+  public SignerConfiguration(
+      final String name,
+      final String keyResource,
+      final String passwordResource,
+      final Address address) {
     this.address = address;
 
     this.resources =

--- a/dsl/src/main/java/tech/pegasys/peeps/signer/SignerConfiguration.java
+++ b/dsl/src/main/java/tech/pegasys/peeps/signer/SignerConfiguration.java
@@ -10,31 +10,22 @@
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
  */
-package tech.pegasys.peeps;
+package tech.pegasys.peeps.signer;
 
-import tech.pegasys.peeps.node.Account;
+import org.apache.tuweni.eth.Address;
+import tech.pegasys.peeps.node.EthereumAddressProvider;
 import tech.pegasys.peeps.signer.model.SignerIdentifier;
 import tech.pegasys.peeps.signer.model.SignerKeyFileResource;
 import tech.pegasys.peeps.signer.model.SignerPasswordFileResource;
 import tech.pegasys.peeps.signer.model.WalletFileResources;
 
-import org.apache.tuweni.eth.Address;
-
-public enum SignerConfiguration {
-  ALPHA(
-      "signer/account/funded/wallet_a.v3",
-      "signer/account/funded/wallet_a.pass",
-      Account.ALPHA.address()),
-  BETA(
-      "signer/account/funded/wallet_b.v3",
-      "signer/account/funded/wallet_b.pass",
-      Account.BETA.address());
+public class SignerConfiguration implements EthereumAddressProvider {
 
   private final Address address;
   private final SignerIdentifier id;
   private final WalletFileResources resources;
 
-  SignerConfiguration(
+  public SignerConfiguration(final String name,
       final String keyResource, final String passwordResource, final Address address) {
     this.address = address;
 
@@ -52,7 +43,7 @@ public enum SignerConfiguration {
           }
         };
 
-    this.id = new SignerIdentifier(name());
+    this.id = new SignerIdentifier(name);
   }
 
   public SignerIdentifier id() {
@@ -65,5 +56,10 @@ public enum SignerConfiguration {
 
   public WalletFileResources resources() {
     return resources;
+  }
+
+  @Override
+  public Address getAddress() {
+    return address;
   }
 }

--- a/dsl/src/main/java/tech/pegasys/peeps/util/Await.java
+++ b/dsl/src/main/java/tech/pegasys/peeps/util/Await.java
@@ -25,7 +25,7 @@ import org.awaitility.core.ThrowingRunnable;
 
 public class Await {
 
-  private static final int DEFAULT_TIMEOUT_IN_SECONDS = 20;
+  private static final int DEFAULT_TIMEOUT_IN_SECONDS = 50;
 
   @FormatMethod
   public static <T> Optional<T> awaitPresence(

--- a/dsl/src/test/java/tech/pegasys/peeps/network/NetworkTest.java
+++ b/dsl/src/test/java/tech/pegasys/peeps/network/NetworkTest.java
@@ -104,7 +104,6 @@ public class NetworkTest {
     network.start();
     network.close();
 
-    verify(node).identity();
     verify(node).awaitConnectivity(anyCollection());
     verify(node).start();
     verify(node).stop();
@@ -112,13 +111,12 @@ public class NetworkTest {
   }
 
   @Test
-  public void stopThenClosenMustStopNodeOnlyOnce() {
+  public void stopThenCloseMustStopNodeOnlyOnce() {
     network.addNode(node);
     network.start();
     network.stop();
     network.close();
 
-    verify(node).identity();
     verify(node).awaitConnectivity(anyCollection());
     verify(node).start();
     verify(node).stop();

--- a/dsl/src/test/java/tech/pegasys/peeps/network/NetworkTest.java
+++ b/dsl/src/test/java/tech/pegasys/peeps/network/NetworkTest.java
@@ -48,7 +48,7 @@ public class NetworkTest {
     Runtime.getRuntime().addShutdownHook(new Thread(this::tearDown));
     network = new Network(configurationDirectory, subnet);
 
-    lenient().when(node.identity()).thenReturn(nodeId);
+    lenient().when(node.identity()).thenReturn("alpha");
   }
 
   @AfterEach

--- a/dsl/src/test/java/tech/pegasys/peeps/node/genesis/ibft/GenesisExtraDataIbftLegacyTest.java
+++ b/dsl/src/test/java/tech/pegasys/peeps/node/genesis/ibft/GenesisExtraDataIbftLegacyTest.java
@@ -22,6 +22,7 @@ import java.security.Security;
 import java.util.List;
 
 import org.apache.tuweni.bytes.Bytes;
+import org.apache.tuweni.eth.Address;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.junit.jupiter.api.Test;
 import org.junit.runner.RunWith;
@@ -52,7 +53,12 @@ class GenesisExtraDataIbftLegacyTest {
     final Web3Provider[] mockProviders = new Web3Provider[validatorPublicKeys.size()];
     for (int i = 0; i < validatorPublicKeys.size(); i++) {
       mockProviders[i] = mock(Web3Provider.class);
-      when(mockProviders[i].getAddress()).thenReturn(validatorPublicKeys.get(i));
+      when(mockProviders[i].getAddress())
+          .thenReturn(
+              Address.fromBytes(
+                  org.apache.tuweni.crypto.Hash.keccak256(
+                          Bytes.fromHexString(validatorPublicKeys.get(i)))
+                      .slice(12, 20)));
     }
 
     final Bytes extraDataBytes = GenesisExtraDataIbftLegacy.encode(mockProviders);

--- a/dsl/src/test/java/tech/pegasys/peeps/node/genesis/ibft/GenesisExtraDataIbftLegacyTest.java
+++ b/dsl/src/test/java/tech/pegasys/peeps/node/genesis/ibft/GenesisExtraDataIbftLegacyTest.java
@@ -52,7 +52,7 @@ class GenesisExtraDataIbftLegacyTest {
     final Web3Provider[] mockProviders = new Web3Provider[validatorPublicKeys.size()];
     for (int i = 0; i < validatorPublicKeys.size(); i++) {
       mockProviders[i] = mock(Web3Provider.class);
-      when(mockProviders[i].nodePublicKey()).thenReturn(validatorPublicKeys.get(i));
+      when(mockProviders[i].getAddress()).thenReturn(validatorPublicKeys.get(i));
     }
 
     final Bytes extraDataBytes = GenesisExtraDataIbftLegacy.encode(mockProviders);

--- a/end-to-end-tests/src/test/java/tech/pegasys/peeps/FixedSignerConfigs.java
+++ b/end-to-end-tests/src/test/java/tech/pegasys/peeps/FixedSignerConfigs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 ConsenSys AG.
+ * Copyright 2021 ConsenSys AG.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -9,8 +9,6 @@
  * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
  * specific language governing permissions and limitations under the License.
- *
- * SPDX-License-Identifier: Apache-2.0
  */
 package tech.pegasys.peeps;
 
@@ -19,15 +17,17 @@ import tech.pegasys.peeps.signer.SignerConfiguration;
 
 public class FixedSignerConfigs {
 
-  public static final SignerConfiguration ALPHA = new SignerConfiguration(
-      "alpha",
-      "signer/account/funded/wallet_a.v3",
+  public static final SignerConfiguration ALPHA =
+      new SignerConfiguration(
+          "alpha",
+          "signer/account/funded/wallet_a.v3",
           "signer/account/funded/wallet_a.pass",
-      Account.ALPHA.address());
+          Account.ALPHA.address());
 
-  public static final SignerConfiguration BETA = new SignerConfiguration(
-      "beta",
-      "signer/account/funded/wallet_b.v3",
+  public static final SignerConfiguration BETA =
+      new SignerConfiguration(
+          "beta",
+          "signer/account/funded/wallet_b.v3",
           "signer/account/funded/wallet_b.pass",
-      Account.BETA.address());
+          Account.BETA.address());
 }

--- a/end-to-end-tests/src/test/java/tech/pegasys/peeps/FixedSignerConfigs.java
+++ b/end-to-end-tests/src/test/java/tech/pegasys/peeps/FixedSignerConfigs.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package tech.pegasys.peeps;
+
+import tech.pegasys.peeps.node.Account;
+import tech.pegasys.peeps.signer.SignerConfiguration;
+
+public class FixedSignerConfigs {
+
+  public static final SignerConfiguration ALPHA = new SignerConfiguration(
+      "alpha",
+      "signer/account/funded/wallet_a.v3",
+          "signer/account/funded/wallet_a.pass",
+      Account.ALPHA.address());
+
+  public static final SignerConfiguration BETA = new SignerConfiguration(
+      "beta",
+      "signer/account/funded/wallet_b.v3",
+          "signer/account/funded/wallet_b.pass",
+      Account.BETA.address());
+}

--- a/end-to-end-tests/src/test/java/tech/pegasys/peeps/NetworkTest.java
+++ b/end-to-end-tests/src/test/java/tech/pegasys/peeps/NetworkTest.java
@@ -17,6 +17,7 @@ import tech.pegasys.peeps.network.NetworkAwait;
 import tech.pegasys.peeps.network.NetworkVerify;
 import tech.pegasys.peeps.network.subnet.Subnet;
 import tech.pegasys.peeps.node.NodeVerify;
+import tech.pegasys.peeps.node.Web3Provider;
 import tech.pegasys.peeps.node.rpc.NodeRpc;
 import tech.pegasys.peeps.signer.rpc.SignerRpcSenderKnown;
 
@@ -70,15 +71,15 @@ public abstract class NetworkTest {
     return verify;
   }
 
-  protected NodeVerify verifyOn(final NodeConfiguration id) {
-    return network.verify(id.id());
+  protected NodeVerify verifyOn(final Web3Provider node) {
+    return network.verify(node);
   }
 
   protected SignerRpcSenderKnown execute(final SignerConfiguration id) {
     return network.rpc(id.id(), id.address());
   }
 
-  protected NodeRpc execute(final NodeConfiguration id) {
-    return network.rpc(id.id());
+  protected NodeRpc execute(final Web3Provider web3Provider) {
+    return web3Provider.rpc();
   }
 }

--- a/end-to-end-tests/src/test/java/tech/pegasys/peeps/NetworkTest.java
+++ b/end-to-end-tests/src/test/java/tech/pegasys/peeps/NetworkTest.java
@@ -12,22 +12,24 @@
  */
 package tech.pegasys.peeps;
 
-import tech.pegasys.peeps.network.Network;
-import tech.pegasys.peeps.network.NetworkAwait;
-import tech.pegasys.peeps.network.NetworkVerify;
-import tech.pegasys.peeps.network.subnet.Subnet;
-import tech.pegasys.peeps.node.NodeVerify;
-import tech.pegasys.peeps.node.Web3Provider;
-import tech.pegasys.peeps.node.rpc.NodeRpc;
-import tech.pegasys.peeps.signer.rpc.SignerRpcSenderKnown;
-
 import java.nio.file.Path;
 import java.security.Security;
-
+import org.apache.tuweni.eth.Address;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.io.TempDir;
+import tech.pegasys.peeps.network.Network;
+import tech.pegasys.peeps.network.NetworkAwait;
+import tech.pegasys.peeps.network.NetworkVerify;
+import tech.pegasys.peeps.network.subnet.Subnet;
+import tech.pegasys.peeps.node.GoQuorum;
+import tech.pegasys.peeps.node.NodeVerify;
+import tech.pegasys.peeps.node.Web3Provider;
+import tech.pegasys.peeps.signer.SignerConfiguration;
+import tech.pegasys.peeps.signer.rpc.SignerRpc;
+import tech.pegasys.peeps.signer.rpc.SignerRpcClient;
+import tech.pegasys.peeps.signer.rpc.SignerRpcSenderKnown;
 
 public abstract class NetworkTest {
 
@@ -79,7 +81,11 @@ public abstract class NetworkTest {
     return network.rpc(id.id(), id.address());
   }
 
-  protected NodeRpc execute(final Web3Provider web3Provider) {
-    return web3Provider.rpc();
+  protected SignerRpc execute(final Web3Provider web3Provider) {
+    return web3Provider.theOtherRpc();
+  }
+
+  protected SignerRpcSenderKnown execute(final Web3Provider signingNode, final Address sender) {
+    return new SignerRpcSenderKnown(signingNode.theOtherRpc(), sender);
   }
 }

--- a/end-to-end-tests/src/test/java/tech/pegasys/peeps/NetworkTest.java
+++ b/end-to-end-tests/src/test/java/tech/pegasys/peeps/NetworkTest.java
@@ -12,24 +12,24 @@
  */
 package tech.pegasys.peeps;
 
+import tech.pegasys.peeps.network.Network;
+import tech.pegasys.peeps.network.NetworkAwait;
+import tech.pegasys.peeps.network.NetworkVerify;
+import tech.pegasys.peeps.network.subnet.Subnet;
+import tech.pegasys.peeps.node.NodeVerify;
+import tech.pegasys.peeps.node.Web3Provider;
+import tech.pegasys.peeps.signer.SignerConfiguration;
+import tech.pegasys.peeps.signer.rpc.SignerRpc;
+import tech.pegasys.peeps.signer.rpc.SignerRpcSenderKnown;
+
 import java.nio.file.Path;
 import java.security.Security;
+
 import org.apache.tuweni.eth.Address;
 import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.io.TempDir;
-import tech.pegasys.peeps.network.Network;
-import tech.pegasys.peeps.network.NetworkAwait;
-import tech.pegasys.peeps.network.NetworkVerify;
-import tech.pegasys.peeps.network.subnet.Subnet;
-import tech.pegasys.peeps.node.GoQuorum;
-import tech.pegasys.peeps.node.NodeVerify;
-import tech.pegasys.peeps.node.Web3Provider;
-import tech.pegasys.peeps.signer.SignerConfiguration;
-import tech.pegasys.peeps.signer.rpc.SignerRpc;
-import tech.pegasys.peeps.signer.rpc.SignerRpcClient;
-import tech.pegasys.peeps.signer.rpc.SignerRpcSenderKnown;
 
 public abstract class NetworkTest {
 

--- a/end-to-end-tests/src/test/java/tech/pegasys/peeps/consensus/CliqueConsensusTest.java
+++ b/end-to-end-tests/src/test/java/tech/pegasys/peeps/consensus/CliqueConsensusTest.java
@@ -14,14 +14,14 @@ package tech.pegasys.peeps.consensus;
 
 import tech.pegasys.peeps.FixedSignerConfigs;
 import tech.pegasys.peeps.NetworkTest;
-import tech.pegasys.peeps.node.Account;
-import tech.pegasys.peeps.signer.SignerConfiguration;
 import tech.pegasys.peeps.network.ConsensusMechanism;
 import tech.pegasys.peeps.network.Network;
+import tech.pegasys.peeps.node.Account;
 import tech.pegasys.peeps.node.Web3Provider;
 import tech.pegasys.peeps.node.model.Hash;
 import tech.pegasys.peeps.node.verification.ValueReceived;
 import tech.pegasys.peeps.node.verification.ValueSent;
+import tech.pegasys.peeps.signer.SignerConfiguration;
 
 import org.apache.tuweni.crypto.SECP256K1.KeyPair;
 import org.apache.tuweni.eth.Address;

--- a/end-to-end-tests/src/test/java/tech/pegasys/peeps/consensus/CliqueConsensusTest.java
+++ b/end-to-end-tests/src/test/java/tech/pegasys/peeps/consensus/CliqueConsensusTest.java
@@ -12,11 +12,12 @@
  */
 package tech.pegasys.peeps.consensus;
 
+import tech.pegasys.peeps.FixedSignerConfigs;
 import tech.pegasys.peeps.NetworkTest;
-import tech.pegasys.peeps.SignerConfiguration;
+import tech.pegasys.peeps.node.Account;
+import tech.pegasys.peeps.signer.SignerConfiguration;
 import tech.pegasys.peeps.network.ConsensusMechanism;
 import tech.pegasys.peeps.network.Network;
-import tech.pegasys.peeps.node.Account;
 import tech.pegasys.peeps.node.Web3Provider;
 import tech.pegasys.peeps.node.model.Hash;
 import tech.pegasys.peeps.node.verification.ValueReceived;
@@ -30,7 +31,7 @@ import org.junit.jupiter.api.Test;
 public class CliqueConsensusTest extends NetworkTest {
 
   private Web3Provider alphaNode;
-  private final SignerConfiguration signer = SignerConfiguration.ALPHA;
+  private final SignerConfiguration signer = FixedSignerConfigs.ALPHA;
 
   @Override
   protected void setUpNetwork(final Network network) {
@@ -48,8 +49,8 @@ public class CliqueConsensusTest extends NetworkTest {
 
     verify().consensusOnValueAt(sender, receiver);
 
-    final Wei senderStartBalance = alphaNode.rpc().getBalance(sender);
-    final Wei receiverStartBalance = alphaNode.rpc().getBalance(receiver);
+    final Wei senderStartBalance = execute(alphaNode).getBalance(sender);
+    final Wei receiverStartBalance = execute(alphaNode).getBalance(receiver);
 
     final Hash receipt = execute(signer).transferTo(receiver, transferAmount);
 

--- a/end-to-end-tests/src/test/java/tech/pegasys/peeps/consensus/CliqueConsensusTest.java
+++ b/end-to-end-tests/src/test/java/tech/pegasys/peeps/consensus/CliqueConsensusTest.java
@@ -13,30 +13,31 @@
 package tech.pegasys.peeps.consensus;
 
 import tech.pegasys.peeps.NetworkTest;
-import tech.pegasys.peeps.NodeConfiguration;
 import tech.pegasys.peeps.SignerConfiguration;
 import tech.pegasys.peeps.network.ConsensusMechanism;
 import tech.pegasys.peeps.network.Network;
 import tech.pegasys.peeps.node.Account;
+import tech.pegasys.peeps.node.Web3Provider;
 import tech.pegasys.peeps.node.model.Hash;
 import tech.pegasys.peeps.node.verification.ValueReceived;
 import tech.pegasys.peeps.node.verification.ValueSent;
 
+import org.apache.tuweni.crypto.SECP256K1.KeyPair;
 import org.apache.tuweni.eth.Address;
 import org.apache.tuweni.units.ethereum.Wei;
 import org.junit.jupiter.api.Test;
 
 public class CliqueConsensusTest extends NetworkTest {
 
-  private final NodeConfiguration node = NodeConfiguration.ALPHA;
+  private Web3Provider alphaNode;
   private final SignerConfiguration signer = SignerConfiguration.ALPHA;
 
   @Override
   protected void setUpNetwork(final Network network) {
-    network.addNode(node.id(), node.keys());
-    network.addNode(NodeConfiguration.BETA.id(), NodeConfiguration.BETA.keys());
-    network.set(ConsensusMechanism.CLIQUE, node.id());
-    network.addSigner(signer.id(), signer.resources(), node.id());
+    alphaNode = network.addNode("alpha", KeyPair.random());
+    network.addNode("beta", KeyPair.random());
+    network.set(ConsensusMechanism.CLIQUE, alphaNode);
+    network.addSigner(signer.id(), signer.resources(), alphaNode);
   }
 
   @Test
@@ -47,14 +48,14 @@ public class CliqueConsensusTest extends NetworkTest {
 
     verify().consensusOnValueAt(sender, receiver);
 
-    final Wei senderStartBalance = execute(node).getBalance(sender);
-    final Wei receiverStartBalance = execute(node).getBalance(receiver);
+    final Wei senderStartBalance = alphaNode.rpc().getBalance(sender);
+    final Wei receiverStartBalance = alphaNode.rpc().getBalance(receiver);
 
     final Hash receipt = execute(signer).transferTo(receiver, transferAmount);
 
     await().consensusOnTransactionReceipt(receipt);
 
-    verifyOn(node)
+    verifyOn(alphaNode)
         .transistion(
             new ValueSent(sender, senderStartBalance, receipt),
             new ValueReceived(receiver, receiverStartBalance, transferAmount));

--- a/end-to-end-tests/src/test/java/tech/pegasys/peeps/consensus/EthHashConsensusTest.java
+++ b/end-to-end-tests/src/test/java/tech/pegasys/peeps/consensus/EthHashConsensusTest.java
@@ -13,30 +13,31 @@
 package tech.pegasys.peeps.consensus;
 
 import tech.pegasys.peeps.NetworkTest;
-import tech.pegasys.peeps.NodeConfiguration;
 import tech.pegasys.peeps.SignerConfiguration;
 import tech.pegasys.peeps.network.ConsensusMechanism;
 import tech.pegasys.peeps.network.Network;
 import tech.pegasys.peeps.node.Account;
+import tech.pegasys.peeps.node.Web3Provider;
 import tech.pegasys.peeps.node.model.Hash;
 import tech.pegasys.peeps.node.verification.ValueReceived;
 import tech.pegasys.peeps.node.verification.ValueSent;
 
+import org.apache.tuweni.crypto.SECP256K1.KeyPair;
 import org.apache.tuweni.eth.Address;
 import org.apache.tuweni.units.ethereum.Wei;
 import org.junit.jupiter.api.Test;
 
 public class EthHashConsensusTest extends NetworkTest {
 
-  private final NodeConfiguration node = NodeConfiguration.ALPHA;
+  private Web3Provider alphaNode;
   private final SignerConfiguration signer = SignerConfiguration.ALPHA;
 
   @Override
   protected void setUpNetwork(final Network network) {
-    network.addNode(node.id(), node.keys());
-    network.addNode(NodeConfiguration.BETA.id(), NodeConfiguration.BETA.keys());
+    alphaNode = network.addNode("alpha", KeyPair.random());
+    network.addNode("beta", KeyPair.random());
     network.set(ConsensusMechanism.ETH_HASH);
-    network.addSigner(signer.id(), signer.resources(), node.id());
+    network.addSigner(signer.id(), signer.resources(), alphaNode);
   }
 
   @Test
@@ -47,14 +48,14 @@ public class EthHashConsensusTest extends NetworkTest {
 
     verify().consensusOnValueAt(sender, receiver);
 
-    final Wei senderStartBalance = execute(node).getBalance(sender);
-    final Wei receiverStartBalance = execute(node).getBalance(receiver);
+    final Wei senderStartBalance = execute(alphaNode).getBalance(sender);
+    final Wei receiverStartBalance = execute(alphaNode).getBalance(receiver);
 
     final Hash receipt = execute(signer).transferTo(receiver, transferAmount);
 
     await().consensusOnTransactionReceipt(receipt);
 
-    verifyOn(node)
+    verifyOn(alphaNode)
         .transistion(
             new ValueSent(sender, senderStartBalance, receipt),
             new ValueReceived(receiver, receiverStartBalance, transferAmount));

--- a/end-to-end-tests/src/test/java/tech/pegasys/peeps/consensus/EthHashConsensusTest.java
+++ b/end-to-end-tests/src/test/java/tech/pegasys/peeps/consensus/EthHashConsensusTest.java
@@ -12,8 +12,12 @@
  */
 package tech.pegasys.peeps.consensus;
 
+import org.apache.tuweni.crypto.SECP256K1.KeyPair;
+import org.apache.tuweni.eth.Address;
+import org.apache.tuweni.units.ethereum.Wei;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.peeps.FixedSignerConfigs;
 import tech.pegasys.peeps.NetworkTest;
-import tech.pegasys.peeps.SignerConfiguration;
 import tech.pegasys.peeps.network.ConsensusMechanism;
 import tech.pegasys.peeps.network.Network;
 import tech.pegasys.peeps.node.Account;
@@ -21,16 +25,12 @@ import tech.pegasys.peeps.node.Web3Provider;
 import tech.pegasys.peeps.node.model.Hash;
 import tech.pegasys.peeps.node.verification.ValueReceived;
 import tech.pegasys.peeps.node.verification.ValueSent;
-
-import org.apache.tuweni.crypto.SECP256K1.KeyPair;
-import org.apache.tuweni.eth.Address;
-import org.apache.tuweni.units.ethereum.Wei;
-import org.junit.jupiter.api.Test;
+import tech.pegasys.peeps.signer.SignerConfiguration;
 
 public class EthHashConsensusTest extends NetworkTest {
 
   private Web3Provider alphaNode;
-  private final SignerConfiguration signer = SignerConfiguration.ALPHA;
+  private final SignerConfiguration signer = FixedSignerConfigs.ALPHA;
 
   @Override
   protected void setUpNetwork(final Network network) {

--- a/end-to-end-tests/src/test/java/tech/pegasys/peeps/consensus/EthHashConsensusTest.java
+++ b/end-to-end-tests/src/test/java/tech/pegasys/peeps/consensus/EthHashConsensusTest.java
@@ -12,10 +12,6 @@
  */
 package tech.pegasys.peeps.consensus;
 
-import org.apache.tuweni.crypto.SECP256K1.KeyPair;
-import org.apache.tuweni.eth.Address;
-import org.apache.tuweni.units.ethereum.Wei;
-import org.junit.jupiter.api.Test;
 import tech.pegasys.peeps.FixedSignerConfigs;
 import tech.pegasys.peeps.NetworkTest;
 import tech.pegasys.peeps.network.ConsensusMechanism;
@@ -26,6 +22,11 @@ import tech.pegasys.peeps.node.model.Hash;
 import tech.pegasys.peeps.node.verification.ValueReceived;
 import tech.pegasys.peeps.node.verification.ValueSent;
 import tech.pegasys.peeps.signer.SignerConfiguration;
+
+import org.apache.tuweni.crypto.SECP256K1.KeyPair;
+import org.apache.tuweni.eth.Address;
+import org.apache.tuweni.units.ethereum.Wei;
+import org.junit.jupiter.api.Test;
 
 public class EthHashConsensusTest extends NetworkTest {
 

--- a/end-to-end-tests/src/test/java/tech/pegasys/peeps/consensus/GoQuorumCliqueConsensusTest.java
+++ b/end-to-end-tests/src/test/java/tech/pegasys/peeps/consensus/GoQuorumCliqueConsensusTest.java
@@ -12,10 +12,6 @@
  */
 package tech.pegasys.peeps.consensus;
 
-import org.apache.tuweni.crypto.SECP256K1.KeyPair;
-import org.apache.tuweni.eth.Address;
-import org.apache.tuweni.units.ethereum.Wei;
-import org.junit.jupiter.api.Test;
 import tech.pegasys.peeps.FixedSignerConfigs;
 import tech.pegasys.peeps.NetworkTest;
 import tech.pegasys.peeps.network.ConsensusMechanism;
@@ -28,6 +24,11 @@ import tech.pegasys.peeps.node.verification.ValueReceived;
 import tech.pegasys.peeps.node.verification.ValueSent;
 import tech.pegasys.peeps.signer.SignerConfiguration;
 
+import org.apache.tuweni.crypto.SECP256K1.KeyPair;
+import org.apache.tuweni.eth.Address;
+import org.apache.tuweni.units.ethereum.Wei;
+import org.junit.jupiter.api.Test;
+
 public class GoQuorumCliqueConsensusTest extends NetworkTest {
 
   private Web3Provider alphaNode;
@@ -36,11 +37,8 @@ public class GoQuorumCliqueConsensusTest extends NetworkTest {
   @Override
   protected void setUpNetwork(final Network network) {
     alphaNode = network.addNode("alpha", KeyPair.random(), Web3ProviderType.GOQUORUM, signer);
-    final Web3Provider betaNode = network.addNode("beta", KeyPair.random());
-
+    network.addNode("beta", KeyPair.random());
     network.set(ConsensusMechanism.CLIQUE, signer);
-
-//    network.addSigner(signer.id(), signer.resources(), alphaNode);
   }
 
   @Test

--- a/end-to-end-tests/src/test/java/tech/pegasys/peeps/consensus/GoQuorumCliqueConsensusTest.java
+++ b/end-to-end-tests/src/test/java/tech/pegasys/peeps/consensus/GoQuorumCliqueConsensusTest.java
@@ -18,6 +18,7 @@ import tech.pegasys.peeps.network.ConsensusMechanism;
 import tech.pegasys.peeps.network.Network;
 import tech.pegasys.peeps.node.Account;
 import tech.pegasys.peeps.node.Web3Provider;
+import tech.pegasys.peeps.node.Web3ProviderType;
 import tech.pegasys.peeps.node.model.Hash;
 import tech.pegasys.peeps.node.verification.ValueReceived;
 import tech.pegasys.peeps.node.verification.ValueSent;
@@ -34,7 +35,7 @@ public class GoQuorumCliqueConsensusTest extends NetworkTest {
 
   @Override
   protected void setUpNetwork(final Network network) {
-    alphaNode = network.addNode("alpha", KeyPair.random());
+    alphaNode = network.addNode("alpha", KeyPair.random(), Web3ProviderType.GOQUORUM);
     final Web3Provider betaNode = network.addNode("beta", KeyPair.random());
 
     network.set(ConsensusMechanism.CLIQUE, betaNode);

--- a/end-to-end-tests/src/test/java/tech/pegasys/peeps/consensus/GoQuorumCliqueConsensusTest.java
+++ b/end-to-end-tests/src/test/java/tech/pegasys/peeps/consensus/GoQuorumCliqueConsensusTest.java
@@ -13,33 +13,33 @@
 package tech.pegasys.peeps.consensus;
 
 import tech.pegasys.peeps.NetworkTest;
-import tech.pegasys.peeps.NodeConfiguration;
 import tech.pegasys.peeps.SignerConfiguration;
 import tech.pegasys.peeps.network.ConsensusMechanism;
 import tech.pegasys.peeps.network.Network;
 import tech.pegasys.peeps.node.Account;
-import tech.pegasys.peeps.node.Web3ProviderType;
+import tech.pegasys.peeps.node.Web3Provider;
 import tech.pegasys.peeps.node.model.Hash;
 import tech.pegasys.peeps.node.verification.ValueReceived;
 import tech.pegasys.peeps.node.verification.ValueSent;
 
+import org.apache.tuweni.crypto.SECP256K1.KeyPair;
 import org.apache.tuweni.eth.Address;
 import org.apache.tuweni.units.ethereum.Wei;
 import org.junit.jupiter.api.Test;
 
 public class GoQuorumCliqueConsensusTest extends NetworkTest {
 
-  private final NodeConfiguration node = NodeConfiguration.ALPHA;
+  private Web3Provider alphaNode;
   private final SignerConfiguration signer = SignerConfiguration.ALPHA;
 
   @Override
   protected void setUpNetwork(final Network network) {
-    network.addNode(node.id(), node.keys(), Web3ProviderType.GOQUORUM);
-    network.addNode(NodeConfiguration.BETA.id(), NodeConfiguration.BETA.keys());
+    alphaNode = network.addNode("alpha", KeyPair.random());
+    final Web3Provider betaNode = network.addNode("beta", KeyPair.random());
 
-    network.set(ConsensusMechanism.CLIQUE, NodeConfiguration.BETA.id());
+    network.set(ConsensusMechanism.CLIQUE, betaNode);
 
-    network.addSigner(signer.id(), signer.resources(), node.id());
+    network.addSigner(signer.id(), signer.resources(), alphaNode);
   }
 
   @Test
@@ -50,14 +50,14 @@ public class GoQuorumCliqueConsensusTest extends NetworkTest {
 
     verify().consensusOnValueAt(sender, receiver);
 
-    final Wei senderStartBalance = execute(node).getBalance(sender);
-    final Wei receiverStartBalance = execute(node).getBalance(receiver);
+    final Wei senderStartBalance = execute(alphaNode).getBalance(sender);
+    final Wei receiverStartBalance = execute(alphaNode).getBalance(receiver);
 
     final Hash receipt = execute(signer).transferTo(receiver, transferAmount);
 
     await().consensusOnTransactionReceipt(receipt);
 
-    verifyOn(node)
+    verifyOn(alphaNode)
         .transistion(
             new ValueSent(sender, senderStartBalance, receipt),
             new ValueReceived(receiver, receiverStartBalance, transferAmount));

--- a/end-to-end-tests/src/test/java/tech/pegasys/peeps/consensus/Ibft2ConsensusTest.java
+++ b/end-to-end-tests/src/test/java/tech/pegasys/peeps/consensus/Ibft2ConsensusTest.java
@@ -12,8 +12,12 @@
  */
 package tech.pegasys.peeps.consensus;
 
+import org.apache.tuweni.crypto.SECP256K1.KeyPair;
+import org.apache.tuweni.eth.Address;
+import org.apache.tuweni.units.ethereum.Wei;
+import org.junit.jupiter.api.Test;
+import tech.pegasys.peeps.FixedSignerConfigs;
 import tech.pegasys.peeps.NetworkTest;
-import tech.pegasys.peeps.SignerConfiguration;
 import tech.pegasys.peeps.network.ConsensusMechanism;
 import tech.pegasys.peeps.network.Network;
 import tech.pegasys.peeps.node.Account;
@@ -21,16 +25,12 @@ import tech.pegasys.peeps.node.Web3Provider;
 import tech.pegasys.peeps.node.model.Hash;
 import tech.pegasys.peeps.node.verification.ValueReceived;
 import tech.pegasys.peeps.node.verification.ValueSent;
-
-import org.apache.tuweni.crypto.SECP256K1.KeyPair;
-import org.apache.tuweni.eth.Address;
-import org.apache.tuweni.units.ethereum.Wei;
-import org.junit.jupiter.api.Test;
+import tech.pegasys.peeps.signer.SignerConfiguration;
 
 public class Ibft2ConsensusTest extends NetworkTest {
 
   private Web3Provider alphaNode;
-  private final SignerConfiguration signer = SignerConfiguration.ALPHA;
+  private final SignerConfiguration signer = FixedSignerConfigs.ALPHA;
 
   @Override
   protected void setUpNetwork(final Network network) {

--- a/end-to-end-tests/src/test/java/tech/pegasys/peeps/consensus/Ibft2ConsensusTest.java
+++ b/end-to-end-tests/src/test/java/tech/pegasys/peeps/consensus/Ibft2ConsensusTest.java
@@ -12,10 +12,6 @@
  */
 package tech.pegasys.peeps.consensus;
 
-import org.apache.tuweni.crypto.SECP256K1.KeyPair;
-import org.apache.tuweni.eth.Address;
-import org.apache.tuweni.units.ethereum.Wei;
-import org.junit.jupiter.api.Test;
 import tech.pegasys.peeps.FixedSignerConfigs;
 import tech.pegasys.peeps.NetworkTest;
 import tech.pegasys.peeps.network.ConsensusMechanism;
@@ -26,6 +22,11 @@ import tech.pegasys.peeps.node.model.Hash;
 import tech.pegasys.peeps.node.verification.ValueReceived;
 import tech.pegasys.peeps.node.verification.ValueSent;
 import tech.pegasys.peeps.signer.SignerConfiguration;
+
+import org.apache.tuweni.crypto.SECP256K1.KeyPair;
+import org.apache.tuweni.eth.Address;
+import org.apache.tuweni.units.ethereum.Wei;
+import org.junit.jupiter.api.Test;
 
 public class Ibft2ConsensusTest extends NetworkTest {
 

--- a/end-to-end-tests/src/test/java/tech/pegasys/peeps/consensus/IbftConsensusTest.java
+++ b/end-to-end-tests/src/test/java/tech/pegasys/peeps/consensus/IbftConsensusTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021 ConsenSys AG.
+ * Copyright 2020 ConsenSys AG.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
  * the License. You may obtain a copy of the License at
@@ -11,6 +11,7 @@
  * specific language governing permissions and limitations under the License.
  */
 package tech.pegasys.peeps.consensus;
+
 
 import org.apache.tuweni.crypto.SECP256K1.KeyPair;
 import org.apache.tuweni.eth.Address;
@@ -28,19 +29,27 @@ import tech.pegasys.peeps.node.verification.ValueReceived;
 import tech.pegasys.peeps.node.verification.ValueSent;
 import tech.pegasys.peeps.signer.SignerConfiguration;
 
-public class GoQuorumCliqueConsensusTest extends NetworkTest {
+public class
+
+IbftConsensusTest extends NetworkTest {
 
   private Web3Provider alphaNode;
   private final SignerConfiguration signer = FixedSignerConfigs.ALPHA;
 
+  final KeyPair fromPrivKeyHexString(final String input) {
+//    return KeyPair.fromSecretKey(SecretKey.fromBytes(Bytes32.fromHexString(input)));
+    return KeyPair.random();
+  }
+
   @Override
   protected void setUpNetwork(final Network network) {
-    alphaNode = network.addNode("alpha", KeyPair.random(), Web3ProviderType.GOQUORUM, signer);
-    final Web3Provider betaNode = network.addNode("beta", KeyPair.random());
-
-    network.set(ConsensusMechanism.CLIQUE, signer);
-
-//    network.addSigner(signer.id(), signer.resources(), alphaNode);
+    alphaNode = network.addNode("alpha", fromPrivKeyHexString("131f7f9bfb56c19a3026fd5d9b0f5c0173d53ba7f4ec51e51f4466f5abfa4b06"), Web3ProviderType.GOQUORUM);
+    final Web3Provider betaNode = network.addNode("beta", fromPrivKeyHexString("55ec42a1da04bd05d0ee2c17fe6fb782531478ba8815f9c5f5ef7f90af5edc59"), Web3ProviderType.GOQUORUM);
+    final Web3Provider gammaNode = network.addNode("gamma", fromPrivKeyHexString("9a4b0678a40507b381e1db3d52847217092d08f839b183932cf4feefb06edceb"), Web3ProviderType.GOQUORUM);
+ //   final Web3Provider epsilonNode = network.addNode("epsilon", fromPrivKeyHexString("97bcfadc9f952bc5b60001608e342b702651096ce590bcf2856374925a808d9a"), Web3ProviderType.GOQUORUM);
+    //network.addNode("besu-1", KeyPair.random(), Web3ProviderType.BESU);
+    network.set(ConsensusMechanism.IBFT, alphaNode, betaNode, gammaNode);
+    network.addSigner(signer.id(), signer.resources(), alphaNode);
   }
 
   @Test
@@ -54,7 +63,7 @@ public class GoQuorumCliqueConsensusTest extends NetworkTest {
     final Wei senderStartBalance = execute(alphaNode).getBalance(sender);
     final Wei receiverStartBalance = execute(alphaNode).getBalance(receiver);
 
-    final Hash receipt = execute(alphaNode, sender).transferTo(receiver, transferAmount);
+    final Hash receipt = execute(signer).transferTo(receiver, transferAmount);
 
     await().consensusOnTransactionReceipt(receipt);
 

--- a/end-to-end-tests/src/test/java/tech/pegasys/peeps/consensus/IbftConsensusTest.java
+++ b/end-to-end-tests/src/test/java/tech/pegasys/peeps/consensus/IbftConsensusTest.java
@@ -12,11 +12,6 @@
  */
 package tech.pegasys.peeps.consensus;
 
-
-import org.apache.tuweni.crypto.SECP256K1.KeyPair;
-import org.apache.tuweni.eth.Address;
-import org.apache.tuweni.units.ethereum.Wei;
-import org.junit.jupiter.api.Test;
 import tech.pegasys.peeps.FixedSignerConfigs;
 import tech.pegasys.peeps.NetworkTest;
 import tech.pegasys.peeps.network.ConsensusMechanism;
@@ -29,25 +24,45 @@ import tech.pegasys.peeps.node.verification.ValueReceived;
 import tech.pegasys.peeps.node.verification.ValueSent;
 import tech.pegasys.peeps.signer.SignerConfiguration;
 
-public class
+import org.apache.tuweni.crypto.SECP256K1.KeyPair;
+import org.apache.tuweni.eth.Address;
+import org.apache.tuweni.units.ethereum.Wei;
+import org.junit.jupiter.api.Test;
 
-IbftConsensusTest extends NetworkTest {
+public class IbftConsensusTest extends NetworkTest {
 
   private Web3Provider alphaNode;
   private final SignerConfiguration signer = FixedSignerConfigs.ALPHA;
 
   final KeyPair fromPrivKeyHexString(final String input) {
-//    return KeyPair.fromSecretKey(SecretKey.fromBytes(Bytes32.fromHexString(input)));
+    //    return KeyPair.fromSecretKey(SecretKey.fromBytes(Bytes32.fromHexString(input)));
     return KeyPair.random();
   }
 
   @Override
   protected void setUpNetwork(final Network network) {
-    alphaNode = network.addNode("alpha", fromPrivKeyHexString("131f7f9bfb56c19a3026fd5d9b0f5c0173d53ba7f4ec51e51f4466f5abfa4b06"), Web3ProviderType.GOQUORUM);
-    final Web3Provider betaNode = network.addNode("beta", fromPrivKeyHexString("55ec42a1da04bd05d0ee2c17fe6fb782531478ba8815f9c5f5ef7f90af5edc59"), Web3ProviderType.GOQUORUM);
-    final Web3Provider gammaNode = network.addNode("gamma", fromPrivKeyHexString("9a4b0678a40507b381e1db3d52847217092d08f839b183932cf4feefb06edceb"), Web3ProviderType.GOQUORUM);
- //   final Web3Provider epsilonNode = network.addNode("epsilon", fromPrivKeyHexString("97bcfadc9f952bc5b60001608e342b702651096ce590bcf2856374925a808d9a"), Web3ProviderType.GOQUORUM);
-    //network.addNode("besu-1", KeyPair.random(), Web3ProviderType.BESU);
+    alphaNode =
+        network.addNode(
+            "alpha",
+            fromPrivKeyHexString(
+                "131f7f9bfb56c19a3026fd5d9b0f5c0173d53ba7f4ec51e51f4466f5abfa4b06"),
+            Web3ProviderType.GOQUORUM);
+    final Web3Provider betaNode =
+        network.addNode(
+            "beta",
+            fromPrivKeyHexString(
+                "55ec42a1da04bd05d0ee2c17fe6fb782531478ba8815f9c5f5ef7f90af5edc59"),
+            Web3ProviderType.GOQUORUM);
+    final Web3Provider gammaNode =
+        network.addNode(
+            "gamma",
+            fromPrivKeyHexString(
+                "9a4b0678a40507b381e1db3d52847217092d08f839b183932cf4feefb06edceb"),
+            Web3ProviderType.GOQUORUM);
+    //   final Web3Provider epsilonNode = network.addNode("epsilon",
+    // fromPrivKeyHexString("97bcfadc9f952bc5b60001608e342b702651096ce590bcf2856374925a808d9a"),
+    // Web3ProviderType.GOQUORUM);
+    // network.addNode("besu-1", KeyPair.random(), Web3ProviderType.BESU);
     network.set(ConsensusMechanism.IBFT, alphaNode, betaNode, gammaNode);
     network.addSigner(signer.id(), signer.resources(), alphaNode);
   }

--- a/end-to-end-tests/src/test/java/tech/pegasys/peeps/privacy/PrivacyContractDeploymentTest.java
+++ b/end-to-end-tests/src/test/java/tech/pegasys/peeps/privacy/PrivacyContractDeploymentTest.java
@@ -12,9 +12,10 @@
  */
 package tech.pegasys.peeps.privacy;
 
+import tech.pegasys.peeps.FixedSignerConfigs;
 import tech.pegasys.peeps.NetworkTest;
 import tech.pegasys.peeps.PrivacyManagerConfiguration;
-import tech.pegasys.peeps.SignerConfiguration;
+import tech.pegasys.peeps.signer.SignerConfiguration;
 import tech.pegasys.peeps.contract.SimpleStorage;
 import tech.pegasys.peeps.network.Network;
 import tech.pegasys.peeps.node.Web3Provider;
@@ -27,7 +28,7 @@ import org.junit.jupiter.api.Test;
 public class PrivacyContractDeploymentTest extends NetworkTest {
 
   private Web3Provider alphaNode;
-  private final SignerConfiguration signer = SignerConfiguration.ALPHA;
+  private final SignerConfiguration signer = FixedSignerConfigs.ALPHA;
   private final PrivacyManagerConfiguration privacyManagerAlpha = PrivacyManagerConfiguration.ALPHA;
   private final PrivacyManagerConfiguration privacyManagerBeta = PrivacyManagerConfiguration.BETA;
 

--- a/end-to-end-tests/src/test/java/tech/pegasys/peeps/privacy/PrivacyContractDeploymentTest.java
+++ b/end-to-end-tests/src/test/java/tech/pegasys/peeps/privacy/PrivacyContractDeploymentTest.java
@@ -15,12 +15,12 @@ package tech.pegasys.peeps.privacy;
 import tech.pegasys.peeps.FixedSignerConfigs;
 import tech.pegasys.peeps.NetworkTest;
 import tech.pegasys.peeps.PrivacyManagerConfiguration;
-import tech.pegasys.peeps.signer.SignerConfiguration;
 import tech.pegasys.peeps.contract.SimpleStorage;
 import tech.pegasys.peeps.network.Network;
 import tech.pegasys.peeps.node.Web3Provider;
 import tech.pegasys.peeps.node.model.Hash;
 import tech.pegasys.peeps.privacy.model.PrivacyGroup;
+import tech.pegasys.peeps.signer.SignerConfiguration;
 
 import org.apache.tuweni.crypto.SECP256K1.KeyPair;
 import org.junit.jupiter.api.Test;

--- a/end-to-end-tests/src/test/java/tech/pegasys/peeps/privacy/PrivacyContractDeploymentTest.java
+++ b/end-to-end-tests/src/test/java/tech/pegasys/peeps/privacy/PrivacyContractDeploymentTest.java
@@ -13,19 +13,20 @@
 package tech.pegasys.peeps.privacy;
 
 import tech.pegasys.peeps.NetworkTest;
-import tech.pegasys.peeps.NodeConfiguration;
 import tech.pegasys.peeps.PrivacyManagerConfiguration;
 import tech.pegasys.peeps.SignerConfiguration;
 import tech.pegasys.peeps.contract.SimpleStorage;
 import tech.pegasys.peeps.network.Network;
+import tech.pegasys.peeps.node.Web3Provider;
 import tech.pegasys.peeps.node.model.Hash;
 import tech.pegasys.peeps.privacy.model.PrivacyGroup;
 
+import org.apache.tuweni.crypto.SECP256K1.KeyPair;
 import org.junit.jupiter.api.Test;
 
 public class PrivacyContractDeploymentTest extends NetworkTest {
 
-  private final NodeConfiguration nodeAlpha = NodeConfiguration.ALPHA;
+  private Web3Provider alphaNode;
   private final SignerConfiguration signer = SignerConfiguration.ALPHA;
   private final PrivacyManagerConfiguration privacyManagerAlpha = PrivacyManagerConfiguration.ALPHA;
   private final PrivacyManagerConfiguration privacyManagerBeta = PrivacyManagerConfiguration.BETA;
@@ -34,17 +35,18 @@ public class PrivacyContractDeploymentTest extends NetworkTest {
   protected void setUpNetwork(final Network network) {
     network.addPrivacyManager(privacyManagerAlpha.id(), privacyManagerAlpha.keyPair());
     network.addPrivacyManager(privacyManagerBeta.id(), privacyManagerBeta.keyPair());
+    alphaNode =
+        network.addNode(
+            "alpha",
+            KeyPair.random(),
+            privacyManagerAlpha.id(),
+            privacyManagerAlpha.keyPair().getPublicKey());
     network.addNode(
-        nodeAlpha.id(),
-        nodeAlpha.keys(),
-        privacyManagerAlpha.id(),
-        privacyManagerAlpha.keyPair().getPublicKey());
-    network.addNode(
-        NodeConfiguration.BETA.id(),
-        NodeConfiguration.BETA.keys(),
+        "beta",
+        KeyPair.random(),
         privacyManagerBeta.id(),
         privacyManagerBeta.keyPair().getPublicKey());
-    network.addSigner(signer.id(), signer.resources(), nodeAlpha.id());
+    network.addSigner(signer.id(), signer.resources(), alphaNode);
   }
 
   @Test
@@ -58,11 +60,11 @@ public class PrivacyContractDeploymentTest extends NetworkTest {
 
     await().consensusOnTransactionReceipt(pmt);
 
-    verifyOn(nodeAlpha).successfulTransactionReceipt(pmt);
+    verifyOn(alphaNode).successfulTransactionReceipt(pmt);
     verify().consensusOnTransaction(pmt);
     verify().consensusOnPrivacyTransactionReceipt(pmt);
     verify()
         .privacyGroup(group)
-        .consensusOnPrivacyPayload(execute(nodeAlpha).getTransactionByHash(pmt));
+        .consensusOnPrivacyPayload(execute(alphaNode).getTransactionByHash(pmt));
   }
 }

--- a/gradle/versions.gradle
+++ b/gradle/versions.gradle
@@ -57,7 +57,7 @@ dependencyManagement {
 	dependency 'org.mockito:mockito-junit-jupiter:3.2.4'	
 
     // TestContainers (Docker client wrapper)
-    dependency "org.testcontainers:testcontainers:1.12.5"
+    dependency "org.testcontainers:testcontainers:1.15.2"
 
     // Web3j
     dependency 'org.web3j:abi:4.5.13'


### PR DESCRIPTION
This change removes the use of hard-coded node-keys (via resources) and generates them on the fly.
This also changes the various DSL APIs to work using Web3Signers, rather than just their IDs.