### PR TITLE
Remove blank logging lines in docker output

### DIFF
--- a/dsl/src/main/java/tech/pegasys/peeps/node/Web3Provider.java
+++ b/dsl/src/main/java/tech/pegasys/peeps/node/Web3Provider.java
@@ -82,7 +82,7 @@ public abstract class Web3Provider implements NetworkMember {
       container.start();
 
       container.followOutput(
-          outputFrame -> LOG.info("{}: {}", identity, outputFrame.getUtf8String()));
+          outputFrame -> LOG.info("{}: {}", identity, outputFrame.getUtf8String().stripTrailing()));
 
       signerRpcClient.bind(
           container.getContainerId(),

--- a/dsl/src/main/java/tech/pegasys/peeps/privacy/PrivateTransactionManager.java
+++ b/dsl/src/main/java/tech/pegasys/peeps/privacy/PrivateTransactionManager.java
@@ -81,7 +81,7 @@ public abstract class PrivateTransactionManager implements NetworkMember {
       container.start();
 
       container.followOutput(
-          outputFrame -> LOG.info("{}: {}", getNodeName(), outputFrame.getUtf8String()));
+          outputFrame -> LOG.info("{}: {}", getNodeName(), outputFrame.getUtf8String().stripTrailing()));
 
       transactionManagerRpc.bind(
           container.getContainerId(),

--- a/dsl/src/main/java/tech/pegasys/peeps/privacy/PrivateTransactionManager.java
+++ b/dsl/src/main/java/tech/pegasys/peeps/privacy/PrivateTransactionManager.java
@@ -81,7 +81,8 @@ public abstract class PrivateTransactionManager implements NetworkMember {
       container.start();
 
       container.followOutput(
-          outputFrame -> LOG.info("{}: {}", getNodeName(), outputFrame.getUtf8String().stripTrailing()));
+          outputFrame ->
+              LOG.info("{}: {}", getNodeName(), outputFrame.getUtf8String().stripTrailing()));
 
       transactionManagerRpc.bind(
           container.getContainerId(),


### PR DESCRIPTION
The docker logging output has an extra empty line between each log line at the moment. This removes that.