### PR TITLE
Fix AT failures

### DIFF
--- a/dsl/src/main/java/tech/pegasys/peeps/network/Network.java
+++ b/dsl/src/main/java/tech/pegasys/peeps/network/Network.java
@@ -23,6 +23,7 @@ import tech.pegasys.peeps.node.Account;
 import tech.pegasys.peeps.node.Besu;
 import tech.pegasys.peeps.node.GoQuorum;
 import tech.pegasys.peeps.node.NodeVerify;
+import tech.pegasys.peeps.node.StaticNodesFile;
 import tech.pegasys.peeps.node.Web3Provider;
 import tech.pegasys.peeps.node.Web3ProviderConfigurationBuilder;
 import tech.pegasys.peeps.node.Web3ProviderType;
@@ -96,6 +97,7 @@ public class Network implements Closeable {
   private final List<NetworkMember> members;
 
   private final Map<Web3ProviderType, GenesisFile> genesisFiles;
+  private final Map<Web3Provider, StaticNodesFile> staticNodesFiles;
   private final PathGenerator pathGenerator;
   private final Subnet subnet;
   private final Vertx vertx;
@@ -121,6 +123,7 @@ public class Network implements Closeable {
             new GenesisFile(pathGenerator.uniqueFile()));
 
     this.state = new NetworkState();
+    this.staticNodesFiles = new HashMap<>();
 
     set(ConsensusMechanism.ETH_HASH);
   }
@@ -128,11 +131,9 @@ public class Network implements Closeable {
   public void start() {
     state.start();
     genesisFiles.forEach((k, v) -> v.ensureExists(genesisConfigurations.get(k)));
+    staticNodesFiles.forEach((k, v) -> v.ensureExists(k, nodes));
     if (members.size() != 0) {
-      // assume that first node is to act as bootnode, so start it fully before other nodes.
-      // TODO: NetworkMember should have a flag to identify the bootnode(s)
-      members.get(0).start();
-      members.subList(1, members.size()).stream().parallel().forEach(NetworkMember::start);
+      members.stream().parallel().forEach(NetworkMember::start);
     }
     awaitConnectivity();
   }
@@ -216,11 +217,13 @@ public class Network implements Closeable {
   private Web3Provider addNode(
       final Web3ProviderConfigurationBuilder config, final Web3ProviderType providerType) {
     final Web3Provider web3Provider;
+    final StaticNodesFile staticNodesFile = new StaticNodesFile(pathGenerator.uniqueFile());
     config
         .withVertx(vertx)
         .withContainerNetwork(subnet.network())
         .withIpAddress(subnet.getAddressAndIncrement())
         .withGenesisFile(genesisFiles.get(providerType))
+        .withStaticNodesFile(staticNodesFile)
         .withBootnodeEnodeAddress(bootnodeEnodeAddresses());
     if (providerType.equals(Web3ProviderType.BESU)) {
       web3Provider = new Besu(config.build());
@@ -228,6 +231,7 @@ public class Network implements Closeable {
       web3Provider = new GoQuorum(config.build());
     }
 
+    staticNodesFiles.put(web3Provider, staticNodesFile);
     return addNode(web3Provider);
   }
 

--- a/dsl/src/main/java/tech/pegasys/peeps/network/Network.java
+++ b/dsl/src/main/java/tech/pegasys/peeps/network/Network.java
@@ -365,6 +365,23 @@ public class Network implements Closeable {
     }
   }
 
+  public void verifyConsensusOnBlockNumberIsAtLeast(final long blockNumber) {
+    checkState(
+        nodes.size() > 1, "There must be two or more nodes to be able to verify on consensus");
+
+    await(
+        () ->
+            assertThat(
+                    nodes
+                        .parallelStream()
+                        .map(node -> node.rpc().getBlockNumber())
+                        .allMatch(block -> block >= blockNumber))
+                .isTrue(),
+        60,
+        "Failed to achieve consensus on block number being at least %s",
+        blockNumber);
+  }
+
   // TODO these Mediator method could be refactored elsewhere?
   public NodeVerify verify(final Web3Provider node) {
     return new NodeVerify(node);

--- a/dsl/src/main/java/tech/pegasys/peeps/network/NetworkVerify.java
+++ b/dsl/src/main/java/tech/pegasys/peeps/network/NetworkVerify.java
@@ -33,6 +33,10 @@ public class NetworkVerify {
     network.verifyConsensusOnTransaction(transaction);
   }
 
+  public void consensusOnBlockNumberIsAtLeast(final long blockNumber) {
+    network.verifyConsensusOnBlockNumberIsAtLeast(blockNumber);
+  }
+
   // TODO perhaps a separate specialisation - privacy?
   public void consensusOnPrivacyTransactionReceipt(final Hash transaction) {
     network.verifyConsensusOnPrivacyTransactionReceipt(transaction);

--- a/dsl/src/main/java/tech/pegasys/peeps/node/Besu.java
+++ b/dsl/src/main/java/tech/pegasys/peeps/node/Besu.java
@@ -41,6 +41,7 @@ public class Besu extends Web3Provider {
 
   private static final String BESU_IMAGE = "hyperledger/besu";
   private static final String CONTAINER_GENESIS_FILE = "/etc/besu/genesis.json";
+  private static final String CONTAINER_STATIC_NODES_FILE = "/opt/besu/static-nodes.json";
   private static final String CONTAINER_PRIVACY_PUBLIC_KEY_FILE =
       "/etc/besu/privacy_public_key.pub";
   private static final String CONTAINER_NODE_PRIVATE_KEY_FILE = "/etc/besu/keys/node.priv";
@@ -56,11 +57,11 @@ public class Besu extends Web3Provider {
 
     addPeerToPeerHost(config, commandLineOptions);
     addCorsOrigins(config, commandLineOptions);
-    addBootnodeAddress(config, commandLineOptions);
     addContainerNetwork(config, container);
     addContainerIpAddress(config.getIpAddress(), container);
     addNodePrivateKey(config, commandLineOptions, container);
     addGenesisFile(config, commandLineOptions, container);
+    addStaticNodesFile(config, container);
     commandLineOptions.addAll(List.of("--network-id", "15"));
 
     if (config.isPrivacyEnabled()) {
@@ -107,13 +108,6 @@ public class Besu extends Web3Provider {
     commandLineOptions.add(config.getIpAddress().get());
   }
 
-  private void addBootnodeAddress(
-      final Web3ProviderConfiguration config, final List<String> commandLineOptions) {
-    config
-        .getBootnodeEnodeAddress()
-        .ifPresent(enode -> commandLineOptions.addAll(Lists.newArrayList("--bootnodes", enode)));
-  }
-
   private void addContainerNetwork(
       final Web3ProviderConfiguration config, final GenericContainer<?> container) {
     container.withNetwork(config.getContainerNetwork());
@@ -157,6 +151,12 @@ public class Besu extends Web3Provider {
     commandLineOptions.add(CONTAINER_GENESIS_FILE);
     container.withCopyFileToContainer(
         MountableFile.forHostPath(config.getGenesisFile()), CONTAINER_GENESIS_FILE);
+  }
+
+  private void addStaticNodesFile(
+      final Web3ProviderConfiguration config, final GenericContainer<?> container) {
+    container.withCopyFileToContainer(
+        MountableFile.forHostPath(config.getStaticNodesFile()), CONTAINER_STATIC_NODES_FILE);
   }
 
   private void addPrivacy(

--- a/dsl/src/main/java/tech/pegasys/peeps/node/StaticNodesFile.java
+++ b/dsl/src/main/java/tech/pegasys/peeps/node/StaticNodesFile.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2021 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package tech.pegasys.peeps.node;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public class StaticNodesFile {
+
+  private static final Logger LOG = LogManager.getLogger();
+
+  private final Path staticNodesFile;
+  private static final ObjectMapper objectMapper =
+      new ObjectMapper()
+          .registerModule(new Jdk8Module())
+          .setSerializationInclusion(Include.NON_ABSENT);
+
+  public StaticNodesFile(final Path staticNodesFile) {
+    this.staticNodesFile = staticNodesFile;
+  }
+
+  public void ensureExists(
+      final Web3Provider web3Provider, final List<Web3Provider> web3Providers) {
+    write(web3Provider, web3Providers);
+  }
+
+  public Path getStaticNodesFile() {
+    return staticNodesFile;
+  }
+
+  private void write(final Web3Provider web3Provider, final List<Web3Provider> web3Providers) {
+    final List<String> enodeAddresses =
+        web3Providers.stream().map(Web3Provider::enodeAddress).collect(Collectors.toList());
+    enodeAddresses.remove(web3Provider.enodeAddress());
+    try {
+      objectMapper.writeValue(staticNodesFile.toFile(), enodeAddresses);
+      LOG.info(
+          "Creating static nodes file\n\tLocation: {} \n\tContents: {}",
+          staticNodesFile,
+          enodeAddresses);
+    } catch (IOException e) {
+      throw new IllegalStateException("Failed creating static nodes file " + staticNodesFile);
+    }
+  }
+}

--- a/dsl/src/main/java/tech/pegasys/peeps/node/StaticNodesFile.java
+++ b/dsl/src/main/java/tech/pegasys/peeps/node/StaticNodesFile.java
@@ -48,15 +48,17 @@ public class StaticNodesFile {
 
   private void write(final Web3Provider web3Provider, final List<Web3Provider> web3Providers) {
     final List<String> enodeAddresses =
-        web3Providers.stream().map(Web3Provider::enodeAddress).collect(Collectors.toList());
-    enodeAddresses.remove(web3Provider.enodeAddress());
+        web3Providers.stream()
+            .map(Web3Provider::enodeAddress)
+            .filter(enodeAddress -> !enodeAddress.equals(web3Provider.enodeAddress()))
+            .collect(Collectors.toList());
     try {
       objectMapper.writeValue(staticNodesFile.toFile(), enodeAddresses);
       LOG.info(
           "Creating static nodes file\n\tLocation: {} \n\tContents: {}",
           staticNodesFile,
           enodeAddresses);
-    } catch (IOException e) {
+    } catch (final IOException e) {
       throw new IllegalStateException("Failed creating static nodes file " + staticNodesFile);
     }
   }

--- a/dsl/src/main/java/tech/pegasys/peeps/node/Web3Provider.java
+++ b/dsl/src/main/java/tech/pegasys/peeps/node/Web3Provider.java
@@ -158,6 +158,10 @@ public abstract class Web3Provider implements NetworkMember {
           final Set<String> peerPubKeys = EnodeHelpers.extractPubKeysFromEnodes(peerEnodes);
           final Set<String> connectedPeerPubKeys =
               EnodeHelpers.extractPubKeysFromEnodes(signerRpcClient.getConnectedPeerEnodes());
+          LOG.info(
+              "Connected peersPubKeys {} expected peersPubKeys {}",
+              connectedPeerPubKeys,
+              peerPubKeys);
           assertThat(connectedPeerPubKeys).containsExactlyInAnyOrderElementsOf(peerPubKeys);
         },
         "Failed to connect in time to peers: %s",

--- a/dsl/src/main/java/tech/pegasys/peeps/node/Web3ProviderConfiguration.java
+++ b/dsl/src/main/java/tech/pegasys/peeps/node/Web3ProviderConfiguration.java
@@ -33,6 +33,7 @@ public class Web3ProviderConfiguration {
   private final String privacyUrl;
   private final String privacyMarkerSigningPrivateKeyFile;
   private final KeyPair nodeKeys;
+  private final Path staticNodesFile;
 
   // TODO move these out, they are not related to the node, but test container setups
   private final Network containerNetwork;
@@ -51,7 +52,8 @@ public class Web3ProviderConfiguration {
       final String identity,
       final KeyPair nodeKeys,
       final String bootnodeEnodeAddress,
-      final SignerConfiguration wallet) {
+      final SignerConfiguration wallet,
+      final Path staticNodesFile) {
     this.genesisFile = genesisFile;
     this.enclavePublicKeyResource = privacyManagerPublicKeyResource;
     this.privacyMarkerSigningPrivateKeyFile = privacyMarkerSigningPrivateKeyFile;
@@ -64,6 +66,7 @@ public class Web3ProviderConfiguration {
     this.nodeKeys = nodeKeys;
     this.bootnodeEnodeAddress = bootnodeEnodeAddress;
     this.wallet = Optional.ofNullable(wallet);
+    this.staticNodesFile = staticNodesFile;
   }
 
   public Path getGenesisFile() {
@@ -117,5 +120,9 @@ public class Web3ProviderConfiguration {
 
   public Optional<SignerConfiguration> getWallet() {
     return wallet;
+  }
+
+  public Path getStaticNodesFile() {
+    return staticNodesFile;
   }
 }

--- a/dsl/src/main/java/tech/pegasys/peeps/node/Web3ProviderConfigurationBuilder.java
+++ b/dsl/src/main/java/tech/pegasys/peeps/node/Web3ProviderConfigurationBuilder.java
@@ -40,6 +40,7 @@ public class Web3ProviderConfigurationBuilder {
   private KeyPair nodeKeys;
   private SignerConfiguration wallet;
   private final String privacyMarkerSigningPrivateKeyFile;
+  private StaticNodesFile staticNodesFile;
 
   // TODO these into their own builder, not node related but test container related
   private Network containerNetwork;
@@ -108,6 +109,12 @@ public class Web3ProviderConfigurationBuilder {
     return this;
   }
 
+  public Web3ProviderConfigurationBuilder withStaticNodesFile(
+      final StaticNodesFile staticNodesFile) {
+    this.staticNodesFile = staticNodesFile;
+    return this;
+  }
+
   public Web3ProviderConfiguration build() {
     checkNotNull(genesisFile, "A genesis file path is mandatory");
     checkNotNull(identity, "An identity is mandatory");
@@ -115,6 +122,7 @@ public class Web3ProviderConfigurationBuilder {
     checkNotNull(ipAddress, "Container IP address is mandatory");
     checkNotNull(containerNetwork, "Container network is mandatory");
     checkNotNull(nodeKeys, "Node Key is mandatory");
+    checkNotNull(staticNodesFile, "Static nodes file path is mandatory");
 
     return new Web3ProviderConfiguration(
         genesisFile.getGenesisFile(),
@@ -128,6 +136,7 @@ public class Web3ProviderConfigurationBuilder {
         identity,
         nodeKeys,
         bootnodeEnodeAddress,
-        wallet);
+        wallet,
+        staticNodesFile.getStaticNodesFile());
   }
 }

--- a/dsl/src/main/java/tech/pegasys/peeps/node/genesis/bft/BftConfig.java
+++ b/dsl/src/main/java/tech/pegasys/peeps/node/genesis/bft/BftConfig.java
@@ -19,7 +19,7 @@ public class BftConfig {
 
   public static final int DEFAULT_BLOCK_PERIOD_SECONDS = 2;
   public static final int DEFAULT_EPOCH_LENGTH = 30000;
-  public static final int DEFAULT_REQUEST_TIMEOUT_SECONDS = 10;
+  public static final int DEFAULT_REQUEST_TIMEOUT_SECONDS = 5;
 
   private final int blockPeriodSeconds;
   private final int epochLength;

--- a/dsl/src/main/java/tech/pegasys/peeps/node/rpc/NodeRpc.java
+++ b/dsl/src/main/java/tech/pegasys/peeps/node/rpc/NodeRpc.java
@@ -36,4 +36,6 @@ public interface NodeRpc {
   Transaction getTransactionByHash(Hash transaction);
 
   Wei getBalance(Address account);
+
+  long getBlockNumber();
 }

--- a/dsl/src/main/java/tech/pegasys/peeps/node/rpc/NodeRpcClient.java
+++ b/dsl/src/main/java/tech/pegasys/peeps/node/rpc/NodeRpcClient.java
@@ -22,6 +22,7 @@ import tech.pegasys.peeps.node.rpc.admin.ConnectedPeersResponse;
 import tech.pegasys.peeps.node.rpc.admin.NodeInfo;
 import tech.pegasys.peeps.node.rpc.admin.NodeInfoResponse;
 import tech.pegasys.peeps.node.rpc.eth.GetBalanceResponse;
+import tech.pegasys.peeps.node.rpc.eth.GetBlockNumberResponse;
 import tech.pegasys.peeps.node.rpc.eth.GetTransactionByHashResponse;
 import tech.pegasys.peeps.node.rpc.eth.GetTransactionReceiptResponse;
 import tech.pegasys.peeps.node.rpc.priv.GetPrivateTransactionResponse;
@@ -86,5 +87,9 @@ public class NodeRpcClient extends JsonRpcClient {
   public Wei getBalance(final Address account) {
     return post("eth_getBalance", GetBalanceResponse.class, account.toHexString(), "latest")
         .getResult();
+  }
+
+  public long getBlockNumber() {
+    return post("eth_blockNumber", GetBlockNumberResponse.class).getResult();
   }
 }

--- a/dsl/src/main/java/tech/pegasys/peeps/node/rpc/NodeRpcMandatoryResponse.java
+++ b/dsl/src/main/java/tech/pegasys/peeps/node/rpc/NodeRpcMandatoryResponse.java
@@ -68,6 +68,11 @@ public class NodeRpcMandatoryResponse implements NodeRpc {
   }
 
   @Override
+  public long getBlockNumber() {
+    return awaitData(rpc::getBlockNumber, "Failed to retrieve block number");
+  }
+
+  @Override
   public Set<String> getConnectedPeerIds() {
     return rpc.getConnectedPeerEnodes();
   }

--- a/dsl/src/main/java/tech/pegasys/peeps/node/rpc/eth/GetBlockNumberResponse.java
+++ b/dsl/src/main/java/tech/pegasys/peeps/node/rpc/eth/GetBlockNumberResponse.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2020 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package tech.pegasys.peeps.node.rpc.eth;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.tuweni.units.bigints.UInt64;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class GetBlockNumberResponse {
+
+  private final long result;
+
+  @JsonCreator
+  public GetBlockNumberResponse(@JsonProperty("result") final String blockNumber) {
+    this.result = UInt64.fromHexString(blockNumber).toLong();
+  }
+
+  public long getResult() {
+    return result;
+  }
+}

--- a/dsl/src/main/java/tech/pegasys/peeps/util/Await.java
+++ b/dsl/src/main/java/tech/pegasys/peeps/util/Await.java
@@ -71,6 +71,19 @@ public class Await {
     }
   }
 
+  @FormatMethod
+  public static void await(
+      final ThrowingRunnable condition,
+      final int timeout,
+      final String errorMessage,
+      final Object... errorMessageParameters) {
+    try {
+      await(timeout, condition);
+    } catch (final ConditionTimeoutException e) {
+      throw new AssertionError(String.format(errorMessage, errorMessageParameters));
+    }
+  }
+
   private static void await(final int timeout, final ThrowingRunnable condition) {
     Awaitility.await()
         .ignoreExceptions()

--- a/end-to-end-tests/src/test/java/tech/pegasys/peeps/consensus/qbft/GoQuorumAndBesuQbftConsensusTest.java
+++ b/end-to-end-tests/src/test/java/tech/pegasys/peeps/consensus/qbft/GoQuorumAndBesuQbftConsensusTest.java
@@ -45,6 +45,8 @@ public class GoQuorumAndBesuQbftConsensusTest extends NetworkTest {
 
   @Test
   public void consensusAfterMiningMustHappen() {
+    verify().consensusOnBlockNumberIsAtLeast(1);
+
     final Address sender = signer.address();
     final Address receiver = Account.BETA.address();
     final Wei transferAmount = Wei.valueOf(5000L);


### PR DESCRIPTION
Improve stability of PEEPS end to end tests

* Wait for first block in QBFT tests before doing transactions to ensure that all nodes are creating blocks and not syncing rounds
* Use static nodes files instead of boot nodes to improve issues with peers not being found

Fixes #70 