### PR TITLE
disable quorum peer discovery

### DIFF
--- a/dsl/src/main/java/tech/pegasys/peeps/node/GoQuorum.java
+++ b/dsl/src/main/java/tech/pegasys/peeps/node/GoQuorum.java
@@ -135,6 +135,7 @@ public class GoQuorum extends Web3Provider {
         "--gasprice",
         "0",
         "--debug",
+        "--nodiscover",
         "--istanbul.blockperiod",
         Integer.toString(blockPeriodSeconds),
         "--istanbul.requesttimeout",


### PR DESCRIPTION
Disable quorum peer discovery in tests to avoid outside peers interfering with the test. 

The additional peer connections were filling up the peer table and make it unreliable for peers to be added and removed during the validator add and remove tests.