### PR TITLE
Ensure that we use the latest EthSigner docker image

### DIFF
--- a/dsl/src/main/java/tech/pegasys/peeps/node/genesis/ibft/GoQuorumIbftOptions.java
+++ b/dsl/src/main/java/tech/pegasys/peeps/node/genesis/ibft/GoQuorumIbftOptions.java
@@ -79,7 +79,7 @@ public class GoQuorumIbftOptions {
     return requestTimeoutSeconds;
   }
 
-  @JsonGetter("qibftblock")
+  @JsonGetter("qbftblock")
   public Optional<Integer> getQbftBlock() {
     return qbftBlock;
   }

--- a/dsl/src/main/java/tech/pegasys/peeps/signer/EthSigner.java
+++ b/dsl/src/main/java/tech/pegasys/peeps/signer/EthSigner.java
@@ -38,6 +38,7 @@ import org.testcontainers.containers.ContainerLaunchException;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.HttpWaitStrategy;
 import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.images.PullPolicy;
 
 public class EthSigner implements NetworkMember {
 
@@ -59,7 +60,9 @@ public class EthSigner implements NetworkMember {
 
   public EthSigner(final EthSignerConfiguration config) {
 
-    final GenericContainer<?> container = new GenericContainer<>(ETH_SIGNER_IMAGE);
+    final GenericContainer<?> container =
+        new GenericContainer<>(ETH_SIGNER_IMAGE)
+            .withImagePullPolicy(PullPolicy.ageBased(Duration.ofHours(1)));
     final List<String> commandLineOptions = standardCommandLineOptions();
 
     addChainId(config, commandLineOptions);
@@ -85,6 +88,14 @@ public class EthSigner implements NetworkMember {
   public void start() {
     try {
       ethSigner.start();
+
+      LOG.info(
+          "Started container {} with imageId {}",
+          ethSigner.getDockerImageName(),
+          ethSigner.getContainerInfo().getImageId());
+
+      ethSigner.followOutput(
+          outputFrame -> LOG.info("{}", outputFrame.getUtf8String().stripTrailing()));
 
       jsonRpcClient.bind(
           ethSigner.getContainerId(),

--- a/dsl/src/main/java/tech/pegasys/peeps/signer/EthSigner.java
+++ b/dsl/src/main/java/tech/pegasys/peeps/signer/EthSigner.java
@@ -90,7 +90,7 @@ public class EthSigner implements NetworkMember {
       ethSigner.start();
 
       LOG.info(
-          "Started container {} with imageId {}",
+          "Started EthSigner container {} with imageId {}",
           ethSigner.getDockerImageName(),
           ethSigner.getContainerInfo().getImageId());
 


### PR DESCRIPTION
Circle caches the the docker image so need to ensure that we pull the latest docker image for EthSigner. We already do this for the Besu and GoQuorum docker images.

Also added some logging similar to what we do for the web3provider dockers so can see what going on in EthSigner.