### PR TITLE
Fix CircleCI build not installing Java 11

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,14 +69,6 @@ jobs:
     steps:
       - prepare
       - run:
-          name: Install Packages - Java 11
-          command: |
-            sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 78BD65473CB3BD13 5DC22404A6F9F1CA
-            sudo add-apt-repository -y ppa:openjdk-r/ppa
-            sudo apt update
-            sudo apt install -y openjdk-11-jdk
-            sudo update-java-alternatives -s java-1.11.0-openjdk-amd64   
-      - run:
           name: Build
           command: |
             ./gradlew --no-daemon --parallel build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,7 +79,7 @@ jobs:
       - run:
           name: Build
           command: |
-            ./gradlew --no-daemon --parallel build
+            ./gradlew --no-daemon --parallel build --debug
       - run:
           name: Test
           no_output_timeout: 20m

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,7 +79,7 @@ jobs:
       - run:
           name: Build
           command: |
-            ./gradlew --no-daemon --parallel build --debug
+            ./gradlew --no-daemon --parallel build
       - run:
           name: Test
           no_output_timeout: 20m

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ executors:
 
   executor_machine:
     machine:
-      image: ubuntu-1604:201903-01 #Ubuntu 16.04, docker 18.09.3, docker-compose 1.23.1
+      image: ubuntu-2004:202107-02 #Ubuntu 20.04, Docker v20.10.7, Docker Compose v1.29.2
       docker_layer_caching: true
     working_directory: ~/project
 


### PR DESCRIPTION
Update machine image to latest ubuntu 20.04 to fix build issue installing Java. With this latest ubuntu Java 11 is included so the Java installation is no longer required either.