### PR TITLE
Use the locally built image if it exists.

### DIFF
--- a/dsl/src/main/java/tech/pegasys/peeps/node/Besu.java
+++ b/dsl/src/main/java/tech/pegasys/peeps/node/Besu.java
@@ -31,7 +31,6 @@ import org.testcontainers.containers.BindMode;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.HttpWaitStrategy;
 import org.testcontainers.containers.wait.strategy.Wait;
-import org.testcontainers.images.PullPolicy;
 import org.testcontainers.utility.MountableFile;
 
 public class Besu extends Web3Provider {
@@ -54,7 +53,7 @@ public class Besu extends Web3Provider {
     super(
         config,
         new GenericContainer<>(BESU_IMAGE)
-            .withImagePullPolicy(PullPolicy.ageBased(Duration.ofHours(1))));
+            .withImagePullPolicy(new LocalAgeBasedPullPolicy(Duration.ofHours(1))));
     final List<String> commandLineOptions = standardCommandLineOptions();
 
     addPeerToPeerHost(config, commandLineOptions);

--- a/dsl/src/main/java/tech/pegasys/peeps/node/GoQuorum.java
+++ b/dsl/src/main/java/tech/pegasys/peeps/node/GoQuorum.java
@@ -30,7 +30,6 @@ import org.testcontainers.containers.BindMode;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.AbstractWaitStrategy;
 import org.testcontainers.containers.wait.strategy.Wait;
-import org.testcontainers.images.PullPolicy;
 import org.testcontainers.utility.MountableFile;
 
 public class GoQuorum extends Web3Provider {
@@ -56,7 +55,7 @@ public class GoQuorum extends Web3Provider {
     super(
         config,
         new GenericContainer<>(IMAGE_NAME)
-            .withImagePullPolicy(PullPolicy.ageBased(Duration.ofHours(1))));
+            .withImagePullPolicy(new LocalAgeBasedPullPolicy(Duration.ofHours(1))));
 
     final List<String> commandLineOptions =
         standardCommandLineOptions(blockPeriodSeconds, requestTimeoutSeconds);

--- a/dsl/src/main/java/tech/pegasys/peeps/node/LocalAgeBasedPullPolicy.java
+++ b/dsl/src/main/java/tech/pegasys/peeps/node/LocalAgeBasedPullPolicy.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2022 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package tech.pegasys.peeps.node;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZonedDateTime;
+
+import com.github.dockerjava.api.DockerClient;
+import com.github.dockerjava.api.command.InspectImageResponse;
+import com.github.dockerjava.api.exception.NotFoundException;
+import org.testcontainers.DockerClientFactory;
+import org.testcontainers.images.AbstractImagePullPolicy;
+import org.testcontainers.images.ImageData;
+import org.testcontainers.utility.DockerImageName;
+
+class LocalAgeBasedPullPolicy extends AbstractImagePullPolicy {
+
+  private final Duration maxAge;
+
+  DockerClient dockerClient = DockerClientFactory.lazyClient();
+
+  public LocalAgeBasedPullPolicy(final Duration maxAge) {
+    this.maxAge = maxAge;
+  }
+
+  @Override
+  protected boolean shouldPullCached(
+      final DockerImageName imageName, final ImageData localImageData) {
+    InspectImageResponse response = null;
+    try {
+      response = dockerClient.inspectImageCmd(imageName.asCanonicalNameString()).exec();
+    } catch (NotFoundException e) {
+      return shouldPullCached(localImageData);
+    }
+
+    if (response != null) {
+      Duration localImageAge =
+          Duration.between(ZonedDateTime.parse(response.getCreated()).toInstant(), Instant.now());
+      return localImageAge.compareTo(maxAge) > 0;
+    } else {
+      return shouldPullCached(localImageData);
+    }
+  }
+
+  private boolean shouldPullCached(final ImageData localImageData) {
+    Duration imageAge = Duration.between(localImageData.getCreatedAt(), Instant.now());
+    return imageAge.compareTo(maxAge) > 0;
+  }
+}


### PR DESCRIPTION
The `PullPolicy.ageBased` is slightly confusing. It has it's own local cache which always gets filled by pulling the remote image, then it checks the created date!