### PR TITLE
Fix PEEPS build failing on EthSigner docker container

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ executors:
 
   executor_machine:
     machine:
-      image: ubuntu-2204:2022.07.1 #Ubuntu 22.04, Docker v20.10.17, Docker Compose v2.6.0
+      image: ubuntu-2004:202201-02 #Ubuntu 20.04, Docker v20.10.7, Docker Compose v1.29.2
       docker_layer_caching: true
     working_directory: ~/project
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ executors:
 
   executor_machine:
     machine:
-      image: ubuntu-2004:202201-02 #Ubuntu 20.04, Docker v20.10.7, Docker Compose v1.29.2
+      image: ubuntu-2004:202201-02 #Ubuntu 20.04, Docker v20.10.12, Docker Compose v1.29.2, Google Cloud SDK updates
       docker_layer_caching: true
     working_directory: ~/project
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ executors:
 
   executor_machine:
     machine:
-      image: ubuntu-2004:202107-02 #Ubuntu 20.04, Docker v20.10.7, Docker Compose v1.29.2
+      image: ubuntu-2204:2022.07.1 #Ubuntu 22.04, Docker v20.10.17, Docker Compose v2.6.0
       docker_layer_caching: true
     working_directory: ~/project
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ executors:
 
   executor_machine:
     machine:
-      image: ubuntu-2004:202201-02 #Ubuntu 20.04, Docker v20.10.7, Docker Compose v1.29.2
+      image: ubuntu-2004:202107-02 #Ubuntu 20.04, Docker v20.10.7, Docker Compose v1.29.2
       docker_layer_caching: true
     working_directory: ~/project
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,7 +22,7 @@ executors:
 
   executor_machine:
     machine:
-      image: ubuntu-2004:202107-02 #Ubuntu 20.04, Docker v20.10.7, Docker Compose v1.29.2
+      image: ubuntu-2004:202201-02 #Ubuntu 20.04, Docker v20.10.7, Docker Compose v1.29.2
       docker_layer_caching: true
     working_directory: ~/project
 

--- a/build.gradle
+++ b/build.gradle
@@ -9,12 +9,12 @@
 import net.ltgt.gradle.errorprone.CheckSeverity
 
 plugins {
-  id 'com.diffplug.gradle.spotless' version '6.2.0'
+  id 'com.diffplug.spotless' version '6.10.0'
   id 'com.jfrog.bintray' version '1.8.4'
-  id 'com.github.ben-manes.versions' version '0.21.0'
+  id 'com.github.ben-manes.versions' version '0.27.0'
   id 'com.github.hierynomus.license' version '0.16.1'
   id 'io.spring.dependency-management' version '1.0.7.RELEASE'
-  id 'net.ltgt.errorprone' version '1.1.1'
+  id 'net.ltgt.errorprone' version '2.0.2'
   id 'net.researchgate.release' version '2.7.0'
   id "de.undercouch.download" version '4.0.0'
 }
@@ -80,7 +80,7 @@ allprojects {
 
   dependencies { errorprone("com.google.errorprone:error_prone_core") }
 
-  apply plugin: 'com.diffplug.gradle.spotless'
+  apply plugin: 'com.diffplug.spotless'
   spotless {
     java {
       // This path needs to be relative to each project
@@ -99,7 +99,6 @@ allprojects {
       target '*.gradle'
       greclipse().configFile(rootProject.file('gradle/formatter.properties'))
       endWithNewline()
-      paddedCell()
     }
 
     // Below this line are currently only license header tasks

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@
 import net.ltgt.gradle.errorprone.CheckSeverity
 
 plugins {
-  id 'com.diffplug.gradle.spotless' version '3.27.0'
+  id 'com.diffplug.gradle.spotless' version '6.2.0'
   id 'com.jfrog.bintray' version '1.8.4'
   id 'com.github.ben-manes.versions' version '0.21.0'
   id 'com.github.hierynomus.license' version '0.16.1'


### PR DESCRIPTION
Update machine executor so that it can run EthSigner docker image as the latest ethsigner docker image requires a newer container runtime.

Also updated error-prone configuration. It was working in circle ci probably due to dependency caching but was failing when I ran it locally.