### PR TITLE
Specify byzantium for solidity evm version

### DIFF
--- a/dsl/build.gradle
+++ b/dsl/build.gradle
@@ -21,6 +21,10 @@ web3j {
   generatedPackageName = 'tech.pegasys.peeps.contract'
 }
 
+solidity {
+  evmVersion = 'BYZANTIUM'
+}
+
 sourceSets.main.solidity.srcDirs = ["$projectDir/contracts"]
 
 jar {


### PR DESCRIPTION
Specify byzantium for solidity compiling. This fixes an issue with QBFT contract test which compiles the contract to use PUSH0 which isn't specified by the genesis file.